### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # kenken
 
+[![CI](https://github.com/wpm/KenKen/actions/workflows/ci.yml/badge.svg)](https://github.com/wpm/KenKen/actions/workflows/ci.yml)
+
 A Rust library for working with KenKen puzzles.
 
 KenKen is a math-based logic puzzle played on an n×n grid. The grid is divided into cages, each labeled with a target number and an arithmetic operation. The goal is to fill the grid with digits 1 through n such that no digit repeats in any row or column, and the numbers in each cage produce the target value using the given operation.


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions CI badge to README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)