### PR TITLE
Add solutions_at_most() method and document thread safety

### DIFF
--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -1,3 +1,6 @@
+//! `Puzzle` is `Send + Sync` and may be shared across threads or sent
+//! between them. Cloning is cheap (the constraints share an `Arc`).
+
 #![allow(dead_code)]
 use crate::constraints::{AllDifferent, Cage, Cages, PuzzleConstraints};
 use crate::grid::Grid;
@@ -88,11 +91,10 @@ impl Puzzle {
     /// [`Puzzle::solutions`] when the answer is `Multiple`.
     #[must_use]
     pub fn uniqueness(&self) -> Uniqueness {
-        let mut iter = Solver::new(self.clone());
-        match (iter.next(), iter.next()) {
-            (None, _) => Uniqueness::None,
-            (Some(_), None) => Uniqueness::Unique,
-            (Some(_), Some(_)) => Uniqueness::Multiple,
+        match self.solutions_at_most(2) {
+            0 => Uniqueness::None,
+            1 => Uniqueness::Unique,
+            _ => Uniqueness::Multiple,
         }
     }
 
@@ -101,7 +103,20 @@ impl Puzzle {
     /// Use [`Puzzle::uniqueness`] when only the bucket (none / one / many) is needed.
     #[must_use]
     pub fn solutions(&self) -> usize {
-        Solver::new(self.clone()).count()
+        self.solutions_at_most(usize::MAX)
+    }
+
+    /// Count solutions, stopping after `k` are found.
+    /// Returns `min(actual_count, k)`.
+    ///
+    /// `solutions_at_most(0)` returns `0` without invoking the solver.
+    /// `solutions_at_most(usize::MAX)` is equivalent to [`Puzzle::solutions`].
+    #[must_use]
+    pub fn solutions_at_most(&self, k: usize) -> usize {
+        if k == 0 {
+            return 0;
+        }
+        Solver::new(self.clone()).take(k).count()
     }
 }
 
@@ -370,6 +385,62 @@ mod tests {
             solve(puzzle),
             vec![vec![vec![2, 1], vec![1, 2]], vec![vec![1, 2], vec![2, 1]],]
         );
+    }
+
+    #[test]
+    fn solutions_at_most_zero_returns_zero() {
+        let unique = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        let multi = Puzzle::new(2)
+            .unwrap()
+            .insert_cage(row_add(2, 0, 3))
+            .unwrap()
+            .insert_cage(row_add(2, 1, 3))
+            .unwrap();
+        let none = Puzzle::new(2)
+            .unwrap()
+            .insert_cage(given(0, 0, 1))
+            .unwrap()
+            .insert_cage(given(0, 1, 1))
+            .unwrap();
+        assert_eq!(unique.solutions_at_most(0), 0);
+        assert_eq!(multi.solutions_at_most(0), 0);
+        assert_eq!(none.solutions_at_most(0), 0);
+    }
+
+    #[test]
+    fn solutions_at_most_caps_unique_puzzle() {
+        let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        assert_eq!(p.solutions_at_most(1), 1);
+        assert_eq!(p.solutions_at_most(2), 1);
+        assert_eq!(p.solutions_at_most(100), 1);
+    }
+
+    #[test]
+    fn solutions_at_most_caps_multi_solution_puzzle() {
+        let p = Puzzle::new(2)
+            .unwrap()
+            .insert_cage(row_add(2, 0, 3))
+            .unwrap()
+            .insert_cage(row_add(2, 1, 3))
+            .unwrap();
+        let true_count = p.solutions();
+        assert!(true_count >= 2);
+        assert_eq!(p.solutions_at_most(1), 1);
+        assert_eq!(p.solutions_at_most(2), 2);
+        assert_eq!(p.solutions_at_most(100), true_count);
+    }
+
+    #[test]
+    fn solutions_at_most_zero_for_overconstrained() {
+        let p = Puzzle::new(2)
+            .unwrap()
+            .insert_cage(given(0, 0, 1))
+            .unwrap()
+            .insert_cage(given(0, 1, 1))
+            .unwrap();
+        assert_eq!(p.solutions_at_most(0), 0);
+        assert_eq!(p.solutions_at_most(1), 0);
+        assert_eq!(p.solutions_at_most(100), 0);
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -130,6 +130,26 @@ fn fixed_size_one_distribution_yields_unique_puzzles() {
 }
 
 #[test]
+fn puzzle_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Puzzle>();
+}
+
+#[test]
+fn solutions_at_most_caps_count() {
+    let mut r = rng(1);
+    let p = generate(3, &mut r).unwrap();
+    let total = p.solutions();
+    assert_eq!(p.solutions_at_most(0), 0);
+    assert_eq!(p.solutions_at_most(usize::MAX), total);
+    let cap = total.saturating_add(1);
+    assert_eq!(p.solutions_at_most(cap), total);
+    if total > 0 {
+        assert_eq!(p.solutions_at_most(1), 1);
+    }
+}
+
+#[test]
 fn size_distribution_uniform_is_constructible() {
     let dist = SizeDistribution::Uniform { min: 2, max: 3 };
     let p = generate_with(4, &mut rng(5), default_op_policy, dist).unwrap();


### PR DESCRIPTION
## Summary
This PR adds a new `solutions_at_most(k)` method to optimize solution counting when only a bounded number of solutions is needed, and documents that `Puzzle` is `Send + Sync` for thread-safe sharing.

## Key Changes
- **New `solutions_at_most(k)` method**: Counts solutions up to a limit `k`, returning `min(actual_count, k)`. This allows early termination when only checking for uniqueness or a bounded number of solutions.
  - Special case: `solutions_at_most(0)` returns `0` without invoking the solver
  - `solutions_at_most(usize::MAX)` is equivalent to `solutions()`
  
- **Refactored `uniqueness()` method**: Now uses `solutions_at_most(2)` instead of manually iterating, making the code clearer and more efficient by stopping after finding 2 solutions.

- **Refactored `solutions()` method**: Now delegates to `solutions_at_most(usize::MAX)` to reduce code duplication.

- **Added documentation**: Module-level doc comment clarifying that `Puzzle` is `Send + Sync` and that cloning is cheap due to `Arc`-based constraint sharing.

- **Comprehensive test coverage**: Added unit tests validating:
  - `solutions_at_most(0)` always returns 0
  - Capping behavior for unique puzzles
  - Capping behavior for multi-solution puzzles
  - Behavior for overconstrained puzzles
  - Public API tests confirming `Send + Sync` bounds and integration with generated puzzles

## Implementation Details
The `solutions_at_most()` method uses `Solver::take(k)` to limit iteration, providing an efficient way to determine solution uniqueness without counting all solutions when unnecessary.

https://claude.ai/code/session_01SW4gx8NYU4MyXTC7gNHRiv