### PR TITLE
feat: expose public API for designer use (#12)

### DIFF
--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -97,9 +97,10 @@ impl Cage {
     /// Returns the cells covered by this cage.
     ///
     /// Inherent counterpart of the internal `Constraint::cells` so callers can read a
-    /// cage's cells without importing the (crate-private) `Constraint` trait.
+    /// cage's cells without importing the (crate-private) `Constraint` trait. The body
+    /// delegates to that trait method so the two paths share a single source of truth.
     pub fn cells(&self) -> &[Cell] {
-        self.polyomino.as_slice()
+        <Self as Constraint>::cells(self)
     }
 }
 

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -96,8 +96,8 @@ impl Cage {
 
     /// Returns the cells covered by this cage.
     ///
-    /// Inherent counterpart of [`Constraint::cells`] so callers can read a cage's cells
-    /// without importing the [`Constraint`] trait.
+    /// Inherent counterpart of the internal `Constraint::cells` so callers can read a
+    /// cage's cells without importing the (crate-private) `Constraint` trait.
     pub fn cells(&self) -> &[Cell] {
         self.polyomino.as_slice()
     }

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -81,6 +81,26 @@ impl Cage {
     pub const fn polyomino(&self) -> &Polyomino {
         &self.polyomino
     }
+
+    /// Returns a copy of this cage's [`Operation`].
+    #[must_use]
+    pub const fn operation(&self) -> Operation {
+        self.operation
+    }
+
+    /// Returns a slice over the cage's precomputed valid value tuples.
+    #[must_use]
+    pub fn tuples(&self) -> &[Vec<N>] {
+        &self.tuples
+    }
+
+    /// Returns the cells covered by this cage.
+    ///
+    /// Inherent counterpart of [`Constraint::cells`] so callers can read a cage's cells
+    /// without importing the [`Constraint`] trait.
+    pub fn cells(&self) -> &[Cell] {
+        self.polyomino.as_slice()
+    }
 }
 
 impl Constraint for Cage {
@@ -204,7 +224,7 @@ impl PuzzleConstraints {
     }
     fn cage_filter(&self, grid: &Grid) -> Result<ValueFilter, Error> {
         let mut filter = ValueFilter::default();
-        for cage in self.cage.values() {
+        for cage in self.cage.iter() {
             filter = filter * cage.grid_value_filter(grid)?;
         }
         Ok(filter)
@@ -296,8 +316,15 @@ impl Cages {
         self.data.is_empty()
     }
 
-    fn values(&self) -> impl Iterator<Item = &Cage> {
+    /// Iterates over every cage in this set.
+    pub fn iter(&self) -> impl Iterator<Item = &Cage> + '_ {
         self.data.values()
+    }
+
+    /// Returns the cage covering `cell`, or `None` if no cage covers it.
+    #[must_use]
+    pub fn get_at(&self, cell: Cell) -> Option<&Cage> {
+        self.tiling.find_cell(cell).and_then(|p| self.data.get(p))
     }
 }
 
@@ -309,6 +336,52 @@ mod tests {
 
     fn cell(row: Index, column: Index) -> Cell {
         Cell::new(row, column)
+    }
+
+    fn make_cage(cells: &[(Index, Index)], n: N, op: Operation) -> Cage {
+        let cells: Vec<Cell> = cells.iter().map(|&(r, c)| Cell::new(r, c)).collect();
+        Cage::new(n, Polyomino::new(&cells), op)
+    }
+
+    #[test]
+    fn cage_operation_returns_stored_operation() {
+        let cage = make_cage(&[(0, 0), (0, 1)], 4, Operation::Add(5));
+        assert_eq!(cage.operation(), Operation::Add(5));
+    }
+
+    #[test]
+    fn cage_tuples_match_constructor_output() {
+        let cage = make_cage(&[(0, 0)], 4, Operation::Given(3));
+        let tuples = cage.tuples();
+        assert_eq!(tuples, &[vec![3u8]]);
+    }
+
+    #[test]
+    fn cage_cells_inherent_matches_polyomino_slice() {
+        let cage = make_cage(&[(0, 0), (1, 0)], 4, Operation::Add(5));
+        assert_eq!(cage.cells(), cage.polyomino().as_slice());
+    }
+
+    #[test]
+    fn cages_iter_yields_every_cage() {
+        let a = make_cage(&[(0, 0), (0, 1)], 4, Operation::Add(5));
+        let b = make_cage(&[(1, 0), (1, 1)], 4, Operation::Add(5));
+        let cages = Cages::empty(4).insert(a).unwrap().insert(b).unwrap();
+        assert_eq!(cages.iter().count(), 2);
+    }
+
+    #[test]
+    fn cages_get_at_returns_covering_cage() {
+        let a = make_cage(&[(0, 0), (0, 1)], 4, Operation::Add(5));
+        let cages = Cages::empty(4).insert(a).unwrap();
+        let got = cages.get_at(cell(0, 1)).unwrap();
+        assert!(got.cells().contains(&cell(0, 1)));
+    }
+
+    #[test]
+    fn cages_get_at_returns_none_for_uncovered_cell() {
+        let cages = Cages::empty(4);
+        assert!(cages.get_at(cell(0, 0)).is_none());
     }
 
     #[test]

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -67,6 +67,18 @@ impl Grid {
         (0..n).flat_map(move |row| (0..n).map(move |column| Cell::new(row, column)))
     }
 
+    /// Iterates over `(cell, values)` pairs in row-major order.
+    ///
+    /// Walks the underlying flat storage so callers don't need a per-cell
+    /// bounds-check via [`Grid::get`].
+    pub fn iter_with_values(&self) -> impl Iterator<Item = (Cell, Values)> + '_ {
+        let n = self.n;
+        self.cells
+            .iter()
+            .enumerate()
+            .map(move |(i, &values)| (Cell::new(i / n, i % n), values))
+    }
+
     const fn index(&self, cell: &Cell) -> Option<usize> {
         if cell.row < self.n && cell.column < self.n {
             Some(cell.row * self.n + cell.column)
@@ -205,5 +217,23 @@ mod tests {
             }
         }
         assert!(g.is_invalid());
+    }
+
+    #[test]
+    fn iter_with_values_yields_row_major_pairs() {
+        let g = Grid::new(2)
+            .unwrap()
+            .set(&Cell::new(0, 1), Values::new([1]))
+            .set(&Cell::new(1, 0), Values::default());
+        let got: Vec<(Cell, Values)> = g.iter_with_values().collect();
+        assert_eq!(
+            got,
+            vec![
+                (Cell::new(0, 0), Values::full(2)),
+                (Cell::new(0, 1), Values::new([1])),
+                (Cell::new(1, 0), Values::default()),
+                (Cell::new(1, 1), Values::full(2)),
+            ]
+        );
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -44,7 +44,7 @@ impl Grid {
     }
 
     /// Returns a new grid with `cell` set to `values`.
-    pub(crate) fn set(mut self, cell: &Cell, values: Values) -> Self {
+    pub fn set(mut self, cell: &Cell, values: Values) -> Self {
         if let Some(i) = self.index(cell) {
             self.cells[i] = values;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@ mod solver;
 mod tiling;
 mod types;
 
-pub use constraints::Operation;
+pub use constraints::{Cage, Operation};
 pub use generation::{DEFAULT_SIZE_DISTRIBUTION, default_op_policy, generate, generate_with};
+pub use grid::Grid;
 pub use puzzle::{Puzzle, Uniqueness};
+pub use shape::Polyomino;
 pub use tiling::SizeDistribution;
-pub use types::{Error, Index, M, N};
+pub use types::{Cell, Error, Index, M, N, Values};

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -6,7 +6,7 @@ use crate::constraints::{AllDifferent, Cage, Cages, PuzzleConstraints};
 use crate::grid::Grid;
 use crate::shape::Polyomino;
 use crate::solver::{Solver, State};
-use crate::types::{Error, Index, Values};
+use crate::types::{Cell, Error, Index, N, Values};
 use std::sync::Arc;
 
 /// Three-bucket classification of a puzzle's solution count.
@@ -69,7 +69,7 @@ impl Puzzle {
     /// Idempotent: if the exact same cage (by polyomino) is already present, returns unchanged.
     /// # Errors
     /// Returns `Error` if any cell in the cage is already claimed by a *different* cage.
-    pub(crate) fn insert_cage(mut self, cage: Cage) -> Result<Self, Error> {
+    pub fn insert_cage(mut self, cage: Cage) -> Result<Self, Error> {
         let constraints = Arc::make_mut(&mut self.constraints);
         constraints.cage = constraints.cage.clone().insert(cage)?;
         Ok(self)
@@ -78,7 +78,7 @@ impl Puzzle {
     /// Returns a new puzzle with the cage removed.
     ///
     /// Idempotent: if no such cage exists, returns unchanged.
-    pub(crate) fn remove_cage(mut self, polyomino: &Polyomino) -> Self {
+    pub fn remove_cage(mut self, polyomino: &Polyomino) -> Self {
         let constraints = Arc::make_mut(&mut self.constraints);
         constraints.cage = constraints.cage.clone().remove(polyomino);
         self
@@ -117,6 +117,56 @@ impl Puzzle {
             return 0;
         }
         Solver::new(self.clone()).take(k).count()
+    }
+
+    /// Read-only access to the underlying candidate-value grid.
+    pub const fn grid(&self) -> &Grid {
+        &self.grid
+    }
+
+    /// Returns the candidate values currently associated with `cell`.
+    /// # Errors
+    /// Returns `Error` if `cell` is outside the grid bounds.
+    pub fn candidates(&self, cell: Cell) -> Result<Values, Error> {
+        self.grid.get(&cell)
+    }
+
+    /// Iterates over every cell of the grid in row-major order.
+    pub fn cells(&self) -> impl Iterator<Item = Cell> + '_ {
+        self.grid.iter()
+    }
+
+    /// Iterates over cells whose candidate set is a singleton, paired with that value.
+    pub fn singleton_cells(&self) -> impl Iterator<Item = (Cell, N)> + '_ {
+        self.grid.iter().filter_map(move |cell| {
+            let v = self.grid.get(&cell).ok()?;
+            v.is_singleton()
+                .then(|| v.iter().next().map(|n| (cell, n)))?
+        })
+    }
+
+    /// Iterates over cells whose candidate set is empty.
+    pub fn empty_cells(&self) -> impl Iterator<Item = Cell> + '_ {
+        self.grid
+            .iter()
+            .filter(move |cell| self.grid.get(cell).is_ok_and(|v| v.is_empty()))
+    }
+
+    /// Returns the cage covering `cell`, or `None` if none does.
+    #[must_use]
+    pub fn cage_at(&self, cell: Cell) -> Option<&Cage> {
+        self.constraints.cage.get_at(cell)
+    }
+
+    /// Iterates over every cage in the puzzle.
+    pub fn cages(&self) -> impl Iterator<Item = &Cage> + '_ {
+        self.constraints.cage.iter()
+    }
+
+    /// Returns true iff some cage covers `cell`.
+    #[must_use]
+    pub fn is_covered(&self, cell: Cell) -> bool {
+        self.cage_at(cell).is_some()
     }
 }
 
@@ -158,7 +208,7 @@ impl State for Puzzle {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::constraints::{Constraint, Operation};
+    use crate::constraints::Operation;
     use crate::types::Cell;
 
     fn make_cage(cells: &[(usize, usize)], n: u8) -> Cage {
@@ -455,5 +505,108 @@ mod tests {
             solve(puzzle),
             vec![vec![vec![2, 1], vec![1, 2]], vec![vec![1, 2], vec![2, 1]],]
         );
+    }
+
+    fn small_puzzle() -> Puzzle {
+        Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap()
+    }
+
+    #[test]
+    fn grid_returns_underlying_grid() {
+        let p = small_puzzle();
+        assert_eq!(p.grid().n(), 2);
+    }
+
+    #[test]
+    fn candidates_matches_grid_get() {
+        let p = small_puzzle();
+        let cell = Cell::new(0, 0);
+        assert_eq!(p.candidates(cell).unwrap(), p.grid().get(&cell).unwrap());
+    }
+
+    #[test]
+    fn candidates_out_of_bounds_is_err() {
+        let p = small_puzzle();
+        assert!(p.candidates(Cell::new(5, 5)).is_err());
+    }
+
+    #[test]
+    fn cells_visits_every_cell_in_row_major_order() {
+        let p = small_puzzle();
+        let got: Vec<Cell> = p.cells().collect();
+        assert_eq!(
+            got,
+            vec![
+                Cell::new(0, 0),
+                Cell::new(0, 1),
+                Cell::new(1, 0),
+                Cell::new(1, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn singleton_cells_yields_only_singleton_cells() {
+        // A fresh 1×1 puzzle has its lone cell as a singleton {1}.
+        let p = Puzzle::new(1).unwrap();
+        let got: Vec<(Cell, N)> = p.singleton_cells().collect();
+        assert_eq!(got, vec![(Cell::new(0, 0), 1)]);
+    }
+
+    #[test]
+    fn singleton_cells_empty_when_no_singletons() {
+        // A fresh 2×2 puzzle has every cell containing {1, 2} — no singletons.
+        let p = Puzzle::new(2).unwrap();
+        assert_eq!(p.singleton_cells().count(), 0);
+    }
+
+    #[test]
+    fn empty_cells_empty_for_fresh_puzzle() {
+        let p = Puzzle::new(2).unwrap();
+        assert_eq!(p.empty_cells().count(), 0);
+    }
+
+    #[test]
+    fn empty_cells_yields_emptied_cell() {
+        let mut p = Puzzle::new(2).unwrap();
+        p.grid = p.grid.set(&Cell::new(1, 1), Values::default());
+        let got: Vec<Cell> = p.empty_cells().collect();
+        assert_eq!(got, vec![Cell::new(1, 1)]);
+    }
+
+    #[test]
+    fn cage_at_returns_covering_cage() {
+        let p = small_puzzle();
+        let cage = p.cage_at(Cell::new(0, 0)).unwrap();
+        assert_eq!(cage.operation(), Operation::Given(1));
+    }
+
+    #[test]
+    fn cage_at_returns_none_for_uncovered_cell() {
+        let p = small_puzzle();
+        assert!(p.cage_at(Cell::new(1, 1)).is_none());
+    }
+
+    #[test]
+    fn cages_iterates_every_cage() {
+        let p = Puzzle::new(2)
+            .unwrap()
+            .insert_cage(given(0, 0, 1))
+            .unwrap()
+            .insert_cage(given(1, 1, 2))
+            .unwrap();
+        assert_eq!(p.cages().count(), 2);
+    }
+
+    #[test]
+    fn is_covered_true_for_covered_cell() {
+        let p = small_puzzle();
+        assert!(p.is_covered(Cell::new(0, 0)));
+    }
+
+    #[test]
+    fn is_covered_false_for_uncovered_cell() {
+        let p = small_puzzle();
+        assert!(!p.is_covered(Cell::new(1, 1)));
     }
 }

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -138,18 +138,19 @@ impl Puzzle {
 
     /// Iterates over cells whose candidate set is a singleton, paired with that value.
     pub fn singleton_cells(&self) -> impl Iterator<Item = (Cell, N)> + '_ {
-        self.grid.iter().filter_map(move |cell| {
-            let v = self.grid.get(&cell).ok()?;
-            v.is_singleton()
-                .then(|| v.iter().next().map(|n| (cell, n)))?
+        self.grid.iter_with_values().filter_map(|(cell, v)| {
+            if !v.is_singleton() {
+                return None;
+            }
+            v.iter().next().map(|n| (cell, n))
         })
     }
 
     /// Iterates over cells whose candidate set is empty.
     pub fn empty_cells(&self) -> impl Iterator<Item = Cell> + '_ {
         self.grid
-            .iter()
-            .filter(move |cell| self.grid.get(cell).is_ok_and(Values::is_empty))
+            .iter_with_values()
+            .filter_map(|(cell, v)| v.is_empty().then_some(cell))
     }
 
     /// Returns the cage covering `cell`, or `None` if none does.

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -149,7 +149,7 @@ impl Puzzle {
     pub fn empty_cells(&self) -> impl Iterator<Item = Cell> + '_ {
         self.grid
             .iter()
-            .filter(move |cell| self.grid.get(cell).is_ok_and(|v| v.is_empty()))
+            .filter(move |cell| self.grid.get(cell).is_ok_and(Values::is_empty))
     }
 
     /// Returns the cage covering `cell`, or `None` if none does.

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -4,8 +4,8 @@
 #![allow(clippy::unwrap_used)]
 
 use kenken::{
-    DEFAULT_SIZE_DISTRIBUTION, Index, N, Operation, Puzzle, SizeDistribution, Uniqueness,
-    default_op_policy, generate, generate_with,
+    Cage, Cell, DEFAULT_SIZE_DISTRIBUTION, Grid, Index, N, Operation, Polyomino, Puzzle,
+    SizeDistribution, Uniqueness, Values, default_op_policy, generate, generate_with,
 };
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -154,4 +154,85 @@ fn size_distribution_uniform_is_constructible() {
     let dist = SizeDistribution::Uniform { min: 2, max: 3 };
     let p = generate_with(4, &mut rng(5), default_op_policy, dist).unwrap();
     assert_ne!(p.uniqueness(), Uniqueness::None);
+}
+
+fn given_cage(row: Index, column: Index, value: N) -> Cage {
+    let cell = Cell::new(row, column);
+    Cage::new(value, Polyomino::new(&[cell]), Operation::Given(value))
+}
+
+#[test]
+fn puzzle_insert_and_remove_cage_are_public() {
+    let cage = given_cage(0, 0, 1);
+    let poly = cage.polyomino().clone();
+    let p = Puzzle::new(2).unwrap().insert_cage(cage).unwrap();
+    assert!(p.is_covered(Cell::new(0, 0)));
+    let p = p.remove_cage(&poly);
+    assert!(!p.is_covered(Cell::new(0, 0)));
+}
+
+#[test]
+fn grid_set_is_public_and_round_trips() {
+    let g: Grid = Grid::new(3).unwrap();
+    let cell = Cell::new(1, 2);
+    let one = Values::new([1]);
+    let g = g.set(&cell, one);
+    assert_eq!(g.get(&cell).unwrap(), one);
+}
+
+#[test]
+fn cage_inherent_accessors_are_reachable() {
+    let cage = given_cage(0, 0, 1);
+    assert_eq!(cage.operation(), Operation::Given(1));
+    assert_eq!(cage.cells(), &[Cell::new(0, 0)]);
+    assert_eq!(cage.tuples(), &[vec![1u8]]);
+}
+
+#[test]
+fn puzzle_grid_and_candidates_expose_state() {
+    let p = Puzzle::new(2)
+        .unwrap()
+        .insert_cage(given_cage(0, 0, 1))
+        .unwrap();
+    let grid: &Grid = p.grid();
+    assert_eq!(grid.n(), 2);
+    let v: Values = p.candidates(Cell::new(0, 1)).unwrap();
+    assert_eq!(v, Values::full(2));
+}
+
+#[test]
+fn puzzle_cells_visits_every_grid_cell() {
+    let p = Puzzle::new(2).unwrap();
+    assert_eq!(p.cells().count(), 4);
+}
+
+#[test]
+fn fresh_puzzle_has_no_singletons_or_empty_cells() {
+    // Fresh 2×2 has every cell containing {1, 2}: no singletons and no empties.
+    let p = Puzzle::new(2).unwrap();
+    assert_eq!(p.singleton_cells().count(), 0);
+    assert_eq!(p.empty_cells().count(), 0);
+}
+
+#[test]
+fn singleton_grid_yields_its_only_cell() {
+    // 1×1: the lone cell holds {1}, which is a singleton by construction.
+    let p = Puzzle::new(1).unwrap();
+    let singletons: Vec<(Cell, N)> = p.singleton_cells().collect();
+    assert_eq!(singletons, vec![(Cell::new(0, 0), 1)]);
+}
+
+#[test]
+fn puzzle_cage_accessors_are_reachable() {
+    let p = Puzzle::new(2)
+        .unwrap()
+        .insert_cage(given_cage(0, 0, 1))
+        .unwrap()
+        .insert_cage(given_cage(1, 1, 2))
+        .unwrap();
+    assert_eq!(p.cages().count(), 2);
+    let cage_at = p.cage_at(Cell::new(0, 0)).unwrap();
+    assert_eq!(cage_at.operation(), Operation::Given(1));
+    assert!(p.is_covered(Cell::new(1, 1)));
+    assert!(!p.is_covered(Cell::new(0, 1)));
 }


### PR DESCRIPTION
Closes #12.

## Summary

Promotes several `pub(crate)` items to `pub`, re-exports five additional types from `lib.rs`, and adds read-only accessors needed by the forthcoming `kenken-designer` wrapper crate. Purely additive — no existing semantics change.

### Re-exports added in `lib.rs`
- `Cell`, `Values` (from `types`)
- `Cage` (from `constraints`)
- `Polyomino` (from `shape`)
- `Grid` (from `grid`)

### Visibility promotions
- `Puzzle::insert_cage`, `Puzzle::remove_cage`: `pub(crate)` → `pub`
- `Grid::set`: `pub(crate)` → `pub`

### New inherent methods on `Cage`
- `operation()` — returns the cage's `Operation` by value.
- `tuples()` — slice of precomputed valid value tuples.
- `cells()` — inherent counterpart of `Constraint::cells`, so callers don't need to import the trait.

### New methods on `Cages`
- `iter()` — public iterator over every cage (was private `values`).
- `get_at(cell)` — looks up the cage covering `cell` via the tiling.

### New read-only methods on `Puzzle`
- `grid()`, `candidates(cell)`, `cells()`, `singleton_cells()`, `empty_cells()`, `cage_at(cell)`, `cages()`, `is_covered(cell)`.

## Test plan
- [x] `cargo test` — 145 unit tests + 21 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New unit tests in `puzzle.rs` cover every new accessor on `Puzzle` and on `Cage`/`Cages`.
- [x] New integration tests in `tests/public_api.rs` confirm every newly-public symbol is reachable from outside the crate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSogftfWCmLuUhkgfRiDKA)_