### PR TITLE
feat: add Polyomino::extend and Polyomino::without

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::types::Cell;
+use crate::types::{Cell, Error};
 use std::collections::HashSet;
 
 /// All cells in a single row of an `n`×`n` grid.
@@ -73,6 +73,46 @@ impl Polyomino {
     #[must_use]
     pub fn contains_cell(&self, cell: Cell) -> bool {
         self.0.binary_search(&cell).is_ok()
+    }
+
+    /// Returns a new polyomino containing every cell of `self` plus `cell`.
+    ///
+    /// # Errors
+    /// - [`Error::CellAlreadyInPolyomino`] if `cell` is already in `self`.
+    /// - [`Error::TargetNotAdjacent`] if `cell` is not 4-adjacent to any cell of `self`.
+    pub fn extend(&self, cell: Cell) -> Result<Self, Error> {
+        let pos = match self.0.binary_search(&cell) {
+            Ok(_) => return Err(Error::CellAlreadyInPolyomino(cell)),
+            Err(pos) => pos,
+        };
+        if !cell.neighbors_4().any(|n| self.contains_cell(n)) {
+            return Err(Error::TargetNotAdjacent);
+        }
+        let mut cells = self.0.clone();
+        cells.insert(pos, cell);
+        Ok(Self(cells))
+    }
+
+    /// Returns a new polyomino containing every cell of `self` except `cell`.
+    ///
+    /// # Errors
+    /// - [`Error::CellNotCovered`] if `cell` is not in `self`.
+    /// - [`Error::RemovalWouldEmptyPolyomino`] if `self` has only one cell.
+    /// - [`Error::FlipWouldDisconnect`] if removal would leave the remaining cells
+    ///   disconnected.
+    pub fn without(&self, cell: Cell) -> Result<Self, Error> {
+        if !self.contains_cell(cell) {
+            return Err(Error::CellNotCovered(cell));
+        }
+        if self.0.len() == 1 {
+            return Err(Error::RemovalWouldEmptyPolyomino);
+        }
+        let mut remaining = self.0.clone();
+        remaining.retain(|c| *c != cell);
+        if !is_connected(&remaining) {
+            return Err(Error::FlipWouldDisconnect(cell));
+        }
+        Ok(Self(remaining))
     }
 }
 
@@ -176,5 +216,64 @@ mod tests {
     #[test]
     fn is_connected_diagonal_is_false() {
         assert!(!is_connected(&[Cell::new(0, 0), Cell::new(1, 1)]));
+    }
+
+    #[test]
+    fn extend_adds_adjacent_cell_to_single_cell_polyomino() {
+        let p = Polyomino::new(&[Cell::new(0, 0)]);
+        let extended = p.extend(Cell::new(0, 1)).unwrap();
+        assert_eq!(extended, Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]));
+    }
+
+    #[test]
+    fn extend_adds_adjacent_cell_to_multi_cell_polyomino() {
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
+        let extended = p.extend(Cell::new(1, 1)).unwrap();
+        assert_eq!(
+            extended,
+            Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1), Cell::new(1, 1)])
+        );
+    }
+
+    #[test]
+    fn extend_errors_on_non_adjacent_cell() {
+        let p = Polyomino::new(&[Cell::new(0, 0)]);
+        let r = p.extend(Cell::new(2, 2));
+        assert!(matches!(r, Err(Error::TargetNotAdjacent)));
+    }
+
+    #[test]
+    fn extend_errors_when_cell_already_present() {
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
+        let r = p.extend(Cell::new(0, 0));
+        assert!(matches!(r, Err(Error::CellAlreadyInPolyomino(_))));
+    }
+
+    #[test]
+    fn without_removes_leaf_of_three_cell_line() {
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1), Cell::new(0, 2)]);
+        let result = p.without(Cell::new(0, 2)).unwrap();
+        assert_eq!(result, Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]));
+    }
+
+    #[test]
+    fn without_errors_when_removal_disconnects() {
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1), Cell::new(0, 2)]);
+        let r = p.without(Cell::new(0, 1));
+        assert!(matches!(r, Err(Error::FlipWouldDisconnect(_))));
+    }
+
+    #[test]
+    fn without_errors_when_cell_not_in_polyomino() {
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
+        let r = p.without(Cell::new(2, 2));
+        assert!(matches!(r, Err(Error::CellNotCovered(_))));
+    }
+
+    #[test]
+    fn without_errors_on_single_cell_polyomino() {
+        let p = Polyomino::new(&[Cell::new(0, 0)]);
+        let r = p.without(Cell::new(0, 0));
+        assert!(matches!(r, Err(Error::RemovalWouldEmptyPolyomino)));
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -104,7 +104,7 @@ impl Polyomino {
             return Err(Error::CellNotCovered(cell));
         }
         if self.0.len() == 1 {
-            return Err(Error::RemovalWouldEmptyPolyomino);
+            return Err(Error::RemovalWouldEmptyPolyomino(cell));
         }
         let mut remaining = self.0.clone();
         remaining.retain(|c| *c != cell);
@@ -277,6 +277,6 @@ mod tests {
     fn without_errors_on_single_cell_polyomino() {
         let p = Polyomino::new(&[Cell::new(0, 0)]);
         let r = p.without(Cell::new(0, 0));
-        assert!(matches!(r, Err(Error::RemovalWouldEmptyPolyomino)));
+        assert!(matches!(r, Err(Error::RemovalWouldEmptyPolyomino(_))));
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -81,9 +81,8 @@ impl Polyomino {
     /// - [`Error::CellAlreadyInPolyomino`] if `cell` is already in `self`.
     /// - [`Error::TargetNotAdjacent`] if `cell` is not 4-adjacent to any cell of `self`.
     pub fn extend(&self, cell: Cell) -> Result<Self, Error> {
-        let pos = match self.0.binary_search(&cell) {
-            Ok(_) => return Err(Error::CellAlreadyInPolyomino(cell)),
-            Err(pos) => pos,
+        let Err(pos) = self.0.binary_search(&cell) else {
+            return Err(Error::CellAlreadyInPolyomino(cell));
         };
         if !cell.neighbors_4().any(|n| self.contains_cell(n)) {
             return Err(Error::TargetNotAdjacent);
@@ -150,6 +149,7 @@ pub fn is_connected_set<S: std::hash::BuildHasher>(cells: &HashSet<Cell, S>) -> 
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -222,7 +222,10 @@ mod tests {
     fn extend_adds_adjacent_cell_to_single_cell_polyomino() {
         let p = Polyomino::new(&[Cell::new(0, 0)]);
         let extended = p.extend(Cell::new(0, 1)).unwrap();
-        assert_eq!(extended, Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]));
+        assert_eq!(
+            extended,
+            Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)])
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -121,7 +121,9 @@ pub enum Error {
     CageConflict(Box<crate::constraints::Cage>, Box<crate::constraints::Cage>),
     /// A tiling operation referenced a cell that no polyomino covers.
     CellNotCovered(Cell),
-    /// A flip would leave the source polyomino disconnected.
+    /// Removing a cell from a polyomino would leave the remaining cells disconnected.
+    /// Raised by `Tiling::flip` (when the source polyomino splits) and by
+    /// `Polyomino::without`.
     FlipWouldDisconnect(Cell),
     /// A flip target polyomino has no cell 4-adjacent to the cell being flipped.
     TargetNotAdjacent,
@@ -129,8 +131,8 @@ pub enum Error {
     PolyominosNotAdjacent,
     /// A cell passed to `Polyomino::extend` is already in the polyomino.
     CellAlreadyInPolyomino(Cell),
-    /// A `Polyomino::without` call would remove the only remaining cell.
-    RemovalWouldEmptyPolyomino,
+    /// A `Polyomino::without` call would remove the polyomino's only remaining cell.
+    RemovalWouldEmptyPolyomino(Cell),
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -127,6 +127,10 @@ pub enum Error {
     TargetNotAdjacent,
     /// Two polyominos passed to `merge_split` are not 4-adjacent.
     PolyominosNotAdjacent,
+    /// A cell passed to `Polyomino::extend` is already in the polyomino.
+    CellAlreadyInPolyomino(Cell),
+    /// A `Polyomino::without` call would remove the only remaining cell.
+    RemovalWouldEmptyPolyomino,
 }
 
 #[cfg(test)]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -233,6 +233,15 @@ fn random_merge_split_is_public() {
 }
 
 #[test]
+fn polyomino_extend_and_without_are_public() {
+    let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
+    let extended = p.extend(Cell::new(0, 2)).unwrap();
+    assert_eq!(extended.as_slice().len(), 3);
+    let shrunk = extended.without(Cell::new(0, 2)).unwrap();
+    assert_eq!(shrunk, p);
+}
+
+#[test]
 fn puzzle_cage_accessors_are_reachable() {
     let p = Puzzle::new(2)
         .unwrap()


### PR DESCRIPTION
## Summary

Adds two pure shape operations on `Polyomino` so the designer can compute new shapes when extending or shrinking a cage, before re-creating the cage with `insert_cage`. Closes #13.

- `Polyomino::extend(cell)` — returns a new polyomino with `cell` added; errors if the cell is already present or not 4-adjacent to any cell.
- `Polyomino::without(cell)` — returns a new polyomino with `cell` removed; errors if the cell is missing, removal would disconnect, or `self` has only one cell. Uses the existing `is_connected` helper for connectivity.

Reuses the existing `CellNotCovered`, `FlipWouldDisconnect`, and `TargetNotAdjacent` error variants where semantics match. Adds two new variants in `src/types.rs` for cases with no obvious match: `CellAlreadyInPolyomino(Cell)` and `RemovalWouldEmptyPolyomino`.

Both methods are reachable through the existing `pub use shape::Polyomino` re-export; a public-API integration test pins this.

## Test plan

- [x] Unit tests in `src/shape.rs` cover all eight cases listed in the issue (4 for `extend`, 4 for `without`)
- [x] Integration test in `tests/public_api.rs` confirms the methods are reachable via the public re-export
- [x] `cargo test` — 22 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean

https://claude.ai/code/session_013WbH27rqhfkcBtuwN4JDV6

---
_Generated by [Claude Code](https://claude.ai/code/session_013WbH27rqhfkcBtuwN4JDV6)_