### PR TITLE
feat: add Delta type with narrow and widen operations

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,0 +1,102 @@
+//! `Delta` is an overlay of candidate-value sets used to transform a [`crate::Puzzle`]'s
+//! grid via [`crate::Puzzle::narrow`] (per-cell intersection) or
+//! [`crate::Puzzle::widen`] (per-cell union).
+
+#![allow(dead_code)]
+
+use crate::grid::Grid;
+use crate::types::{Cell, Error, Index, Values};
+
+/// An overlay of candidate-value sets, shaped like a [`Grid`] but distinguished from it
+/// by the type system: a `Delta` is a transform, not a state.
+#[must_use]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Delta(Grid);
+
+impl Delta {
+    /// Identity delta for an n×n grid: every cell is `Values::full(n)`.
+    ///
+    /// # Errors
+    /// Returns `Error` if `n` is not in `1..=9`.
+    pub fn identity(n: Index) -> Result<Self, Error> {
+        Grid::new(n).map(Self)
+    }
+
+    /// The side length of the underlying grid.
+    #[must_use]
+    pub const fn n(&self) -> Index {
+        self.0.n()
+    }
+
+    /// Returns a new `Delta` with `cell` set to `values`.
+    pub fn set(self, cell: Cell, values: Values) -> Self {
+        Self(self.0.set(&cell, values))
+    }
+
+    /// Returns the values at `cell`.
+    ///
+    /// # Errors
+    /// Returns `Error` if `cell` is outside the grid.
+    pub fn get(&self, cell: Cell) -> Result<Values, Error> {
+        self.0.get(&cell)
+    }
+
+    pub(crate) const fn grid(&self) -> &Grid {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_returns_err_for_invalid_size() {
+        assert!(Delta::identity(0).is_err());
+        assert!(Delta::identity(10).is_err());
+    }
+
+    #[test]
+    fn identity_every_cell_is_full() {
+        let d = Delta::identity(3).unwrap();
+        for row in 0..3 {
+            for column in 0..3 {
+                assert_eq!(d.get(Cell::new(row, column)).unwrap(), Values::full(3));
+            }
+        }
+    }
+
+    #[test]
+    fn n_matches_constructor_argument() {
+        assert_eq!(Delta::identity(4).unwrap().n(), 4);
+    }
+
+    #[test]
+    fn set_overrides_target_cell() {
+        let d = Delta::identity(3)
+            .unwrap()
+            .set(Cell::new(1, 2), Values::new([1]));
+        assert_eq!(d.get(Cell::new(1, 2)).unwrap(), Values::new([1]));
+    }
+
+    #[test]
+    fn set_leaves_other_cells_unchanged() {
+        let d = Delta::identity(3)
+            .unwrap()
+            .set(Cell::new(1, 2), Values::new([1]));
+        assert_eq!(d.get(Cell::new(0, 0)).unwrap(), Values::full(3));
+    }
+
+    #[test]
+    fn get_returns_err_for_out_of_bounds_cell() {
+        let d = Delta::identity(3).unwrap();
+        assert!(d.get(Cell::new(9, 9)).is_err());
+    }
+
+    #[test]
+    fn get_returns_full_for_unset_cell_on_identity() {
+        let d = Delta::identity(2).unwrap();
+        assert_eq!(d.get(Cell::new(0, 1)).unwrap(), Values::full(2));
+    }
+}

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -8,7 +8,7 @@ use crate::types::{Cell, Error, Values};
 /// Stored as a single flat allocation of `n×n` [`Values`] in row-major order,
 /// so cloning is one `memcpy`.
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Grid {
     n: usize,
     cells: Box<[Values]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod arithmetic;
 mod constraints;
+mod delta;
 mod generation;
 mod grid;
 mod latin_square;
@@ -11,6 +12,7 @@ mod tiling;
 mod types;
 
 pub use constraints::{Cage, Operation};
+pub use delta::Delta;
 pub use generation::{DEFAULT_SIZE_DISTRIBUTION, default_op_policy, generate, generate_with};
 pub use grid::Grid;
 pub use puzzle::{Puzzle, Uniqueness};

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -3,6 +3,7 @@
 
 #![allow(dead_code)]
 use crate::constraints::{AllDifferent, Cage, Cages, PuzzleConstraints};
+use crate::delta::Delta;
 use crate::grid::Grid;
 use crate::shape::Polyomino;
 use crate::solver::{Solver, State};
@@ -169,19 +170,96 @@ impl Puzzle {
     pub fn is_covered(&self, cell: Cell) -> bool {
         self.cage_at(cell).is_some()
     }
+
+    /// Returns true iff every cell has at least one candidate value — i.e. propagation
+    /// has not produced a contradiction.
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        !self.grid.is_invalid()
+    }
+
+    /// One round of constraint propagation: builds a value filter from every constraint
+    /// against the current grid and applies it. Always returns a `Puzzle`; the resulting
+    /// grid may be invalid when constraints contradict. Best-effort: returns `self`
+    /// unchanged on the unreachable error path from `apply`.
+    fn propagate_round(self) -> Self {
+        let Ok(filter) = self.constraints.apply(&self.grid) else {
+            return self;
+        };
+        let Ok(grid) = filter.apply(&self.grid) else {
+            return self;
+        };
+        Self {
+            grid,
+            constraints: self.constraints,
+        }
+    }
+
+    /// Iterates one round of constraint propagation until the grid stops changing or
+    /// goes invalid. Always returns a `Puzzle`; the caller inspects [`Self::is_valid`]
+    /// if they care.
+    pub fn propagate_fully(self) -> Self {
+        let mut current = self;
+        loop {
+            let prev_grid = current.grid.clone();
+            let next = current.propagate_round();
+            if next.grid.is_invalid() || next.grid == prev_grid {
+                return next;
+            }
+            current = next;
+        }
+    }
+
+    /// Apply `delta` by intersecting per-cell with the current grid, then propagate to
+    /// fixed point. Always returns a `Puzzle`; the caller inspects [`Self::is_valid`].
+    ///
+    /// # Panics
+    /// Panics if `delta.n()` does not match `self.n()`.
+    pub fn narrow(&self, delta: &Delta) -> Self {
+        self.apply_delta(delta, |a, b| a & b)
+    }
+
+    /// Apply `delta` by unioning per-cell with the current grid, then propagate to
+    /// fixed point. Always returns a `Puzzle`; the caller inspects [`Self::is_valid`].
+    ///
+    /// # Panics
+    /// Panics if `delta.n()` does not match `self.n()`.
+    pub fn widen(&self, delta: &Delta) -> Self {
+        self.apply_delta(delta, |a, b| a | b)
+    }
+
+    fn apply_delta(&self, delta: &Delta, op: impl Fn(Values, Values) -> Values) -> Self {
+        assert_eq!(
+            delta.n(),
+            self.n(),
+            "delta size {} must match puzzle size {}",
+            delta.n(),
+            self.n(),
+        );
+        let mut grid = self.grid.clone();
+        for ((cell, current), (_, delta_v)) in self
+            .grid
+            .iter_with_values()
+            .zip(delta.grid().iter_with_values())
+        {
+            grid = grid.set(&cell, op(current, delta_v));
+        }
+        Self {
+            grid,
+            constraints: self.constraints.clone(),
+        }
+        .propagate_fully()
+    }
 }
 
 impl State for Puzzle {
     fn propagate(self) -> Option<Self> {
-        let filter = self.constraints.apply(&self.grid).ok()?;
-        let grid = filter.apply(&self.grid).ok()?;
-        if grid.is_invalid() {
-            return None;
+        let next = self.propagate_round();
+        if next.grid.is_invalid() {
+            None
+        } else {
+            Some(next)
         }
-        Some(Self {
-            grid,
-            constraints: self.constraints,
-        })
     }
 
     fn branch(self) -> impl Iterator<Item = Self> {
@@ -609,5 +687,163 @@ mod tests {
     fn is_covered_false_for_uncovered_cell() {
         let p = small_puzzle();
         assert!(!p.is_covered(Cell::new(1, 1)));
+    }
+
+    fn add_cage(cells: &[(usize, usize)], n: u8, target: u8) -> Cage {
+        let cells: Vec<Cell> = cells
+            .iter()
+            .map(|&(row, column)| Cell::new(row, column))
+            .collect();
+        Cage::new(n, Polyomino::new(&cells), Operation::Add(target))
+    }
+
+    #[test]
+    fn is_valid_true_for_fresh_puzzle() {
+        assert!(Puzzle::new(2).unwrap().is_valid());
+    }
+
+    #[test]
+    fn is_valid_false_when_a_cell_is_empty() {
+        let mut p = Puzzle::new(2).unwrap();
+        p.grid = p.grid.set(&Cell::new(0, 0), Values::default());
+        assert!(!p.is_valid());
+    }
+
+    #[test]
+    fn propagate_round_leaves_fresh_grid_unchanged() {
+        let p = Puzzle::new(2).unwrap();
+        let before = p.grid.clone();
+        let after = p.propagate_round();
+        assert_eq!(after.grid, before);
+    }
+
+    #[test]
+    fn propagate_round_propagates_given_cage_value() {
+        let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        let after = p.propagate_round();
+        assert_eq!(after.grid.get(&Cell::new(0, 0)).unwrap(), Values::new([1]));
+    }
+
+    #[test]
+    fn propagate_round_yields_empty_for_overconstrained() {
+        // A 2-cell Add cage with target 5 has no valid tuples in 1..=2,
+        // so the cage filter pins both cells to the empty set.
+        let p = Puzzle::new(2)
+            .unwrap()
+            .insert_cage(add_cage(&[(0, 0), (0, 1)], 2, 5))
+            .unwrap();
+        let after = p.propagate_round();
+        assert!(after.grid.is_invalid());
+        assert_eq!(after.grid.get(&Cell::new(0, 0)).unwrap(), Values::default());
+    }
+
+    #[test]
+    fn propagate_fully_reaches_singletons_on_unique_solution() {
+        // Given(0,0,1) on 2×2 forces every cell to a singleton via all-different.
+        let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        let fixed = p.propagate_fully();
+        assert!(fixed.is_valid());
+        for cell in fixed.cells() {
+            assert!(fixed.grid.get(&cell).unwrap().is_singleton());
+        }
+    }
+
+    #[test]
+    fn propagate_fully_yields_invalid_for_overconstrained() {
+        let p = Puzzle::new(2)
+            .unwrap()
+            .insert_cage(add_cage(&[(0, 0), (0, 1)], 2, 5))
+            .unwrap();
+        let fixed = p.propagate_fully();
+        assert!(!fixed.is_valid());
+    }
+
+    #[test]
+    fn propagate_fully_idempotent_at_fixed_point() {
+        let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        let once = p.propagate_fully();
+        let twice = once.clone().propagate_fully();
+        assert_eq!(once.grid, twice.grid);
+    }
+
+    #[test]
+    fn narrow_with_identity_delta_is_no_op() {
+        let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        let baseline = p.clone().propagate_fully();
+        let narrowed = p.narrow(&Delta::identity(2).unwrap());
+        assert_eq!(narrowed.grid, baseline.grid);
+    }
+
+    #[test]
+    fn narrow_with_singleton_delta_pins_cell() {
+        // Pinning (0,0) to {1} on a fresh 2×2 grid forces (0,1)={2}, (1,0)={2}, (1,1)={1}.
+        let p = Puzzle::new(2).unwrap();
+        let delta = Delta::identity(2)
+            .unwrap()
+            .set(Cell::new(0, 0), Values::new([1]));
+        let narrowed = p.narrow(&delta);
+        assert!(narrowed.is_valid());
+        assert_eq!(
+            narrowed.grid.get(&Cell::new(0, 0)).unwrap(),
+            Values::new([1])
+        );
+        assert_eq!(
+            narrowed.grid.get(&Cell::new(0, 1)).unwrap(),
+            Values::new([2])
+        );
+        assert_eq!(
+            narrowed.grid.get(&Cell::new(1, 0)).unwrap(),
+            Values::new([2])
+        );
+        assert_eq!(
+            narrowed.grid.get(&Cell::new(1, 1)).unwrap(),
+            Values::new([1])
+        );
+    }
+
+    #[test]
+    fn narrow_emptying_a_cell_yields_invalid() {
+        let p = Puzzle::new(2).unwrap();
+        let delta = Delta::identity(2)
+            .unwrap()
+            .set(Cell::new(0, 0), Values::default());
+        let narrowed = p.narrow(&delta);
+        assert!(!narrowed.is_valid());
+    }
+
+    #[test]
+    fn widen_with_identity_delta_is_no_op() {
+        let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        let baseline = p.clone().propagate_fully();
+        let widened = p.widen(&Delta::identity(2).unwrap());
+        assert_eq!(widened.grid, baseline.grid);
+    }
+
+    #[test]
+    fn widen_re_narrows_to_constraint_implications() {
+        // Start from the fully-propagated puzzle (every cell singleton). Widen with the
+        // identity delta unions full {1,2} into every cell, then propagation re-narrows
+        // to the same fixed point.
+        let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
+        let baseline = p.propagate_fully();
+        let widened = baseline.widen(&Delta::identity(2).unwrap());
+        assert!(widened.is_valid());
+        for cell in widened.cells() {
+            assert!(widened.grid.get(&cell).unwrap().is_singleton());
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "delta size")]
+    fn narrow_panics_on_size_mismatch() {
+        let p = Puzzle::new(2).unwrap();
+        let _ = p.narrow(&Delta::identity(3).unwrap());
+    }
+
+    #[test]
+    #[should_panic(expected = "delta size")]
+    fn widen_panics_on_size_mismatch() {
+        let p = Puzzle::new(2).unwrap();
+        let _ = p.widen(&Delta::identity(3).unwrap());
     }
 }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::unwrap_used)]
 
 use kenken::{
-    Cage, Cell, DEFAULT_SIZE_DISTRIBUTION, Grid, Index, N, Operation, Polyomino, Puzzle,
+    Cage, Cell, DEFAULT_SIZE_DISTRIBUTION, Delta, Grid, Index, N, Operation, Polyomino, Puzzle,
     SizeDistribution, Uniqueness, Values, default_op_policy, generate, generate_with,
 };
 use rand::SeedableRng;
@@ -235,4 +235,45 @@ fn puzzle_cage_accessors_are_reachable() {
     assert_eq!(cage_at.operation(), Operation::Given(1));
     assert!(p.is_covered(Cell::new(1, 1)));
     assert!(!p.is_covered(Cell::new(0, 1)));
+}
+
+#[test]
+fn delta_narrow_widen_and_propagate_fully_are_public() {
+    // Identity delta is a no-op after propagation, regardless of starting state.
+    let p = Puzzle::new(2).unwrap();
+    let identity = Delta::identity(2).unwrap();
+    let unchanged = p.narrow(&identity);
+    assert!(unchanged.is_valid());
+
+    // Pinning (0,0)={1} on a 2×2 grid forces a unique completion via narrow + propagate.
+    let pinning = Delta::identity(2)
+        .unwrap()
+        .set(Cell::new(0, 0), Values::new([1]));
+    let pinned = Puzzle::new(2).unwrap().narrow(&pinning);
+    assert!(pinned.is_valid());
+    assert_eq!(
+        pinned.candidates(Cell::new(1, 1)).unwrap(),
+        Values::new([1]),
+    );
+
+    // Emptying a cell via narrow yields an invalid puzzle.
+    let emptying = Delta::identity(2)
+        .unwrap()
+        .set(Cell::new(0, 0), Values::new([]));
+    let invalid = Puzzle::new(2).unwrap().narrow(&emptying);
+    assert!(!invalid.is_valid());
+
+    // Widen with the identity over a fully-propagated puzzle re-narrows back to the
+    // same fixed point.
+    let solved = Puzzle::new(2)
+        .unwrap()
+        .insert_cage(given_cage(0, 0, 1))
+        .unwrap()
+        .propagate_fully();
+    let rewidened = solved.widen(&identity);
+    assert!(rewidened.is_valid());
+    assert_eq!(
+        rewidened.candidates(Cell::new(1, 1)).unwrap(),
+        Values::new([1]),
+    );
 }


### PR DESCRIPTION
## Summary

Closes #15.

- Adds a `Delta` newtype around `Grid` (in `src/delta.rs`) representing an overlay of candidate-value sets, exported from `lib.rs`. Provides `identity(n)`, `set(cell, values)`, `get(cell)`, and `n()`.
- Adds `Puzzle::narrow(&Delta)` (per-cell intersection) and `Puzzle::widen(&Delta)` (per-cell union); both propagate to fixed point and always return a `Puzzle`.
- Adds `Puzzle::propagate_fully` that iterates one constraint round until the grid stabilizes or goes invalid, plus `Puzzle::is_valid` so callers can detect contradictions without reaching into the grid.
- Refactors `<Puzzle as State>::propagate` to a thin wrapper around a new no-bail `propagate_round`, so the solver and the new `propagate_fully` share a single round implementation. Solver behavior is unchanged.
- Derives `PartialEq, Eq` on `Grid` to support the fixed-point comparison.

## Test plan

- [x] `cargo test` — 168 unit + 22 public-API tests pass, including new tests for `propagate_round` (no-op on fresh, propagates givens, yields empties on over-constrained), `propagate_fully` (singletons on unique solution, invalid on contradiction, idempotent at fixed point), `Delta` (identity, set, get, size errors), `narrow` (identity no-op, singleton pinning, emptying yields invalid, size-mismatch panic), and `widen` (identity no-op after propagation, re-narrows to constraint implications, size-mismatch panic).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::pedantic -D clippy::nursery -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic ...` clean.
- [x] `cargo doc --no-deps` builds with `RUSTDOCFLAGS=-D warnings`.
- [x] Integration smoke test in `tests/public_api.rs` exercises `Delta`, `Puzzle::narrow`, `Puzzle::widen`, and `Puzzle::propagate_fully` from outside the crate.

---
_Generated by [Claude Code](https://claude.ai/code/session_017gC6tUBMe6AFXcWniatb9e)_