### PR TITLE
fix(ci): generate lcov coverage report for Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt, clippy, llvm-tools
 
       - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Format
         run: cargo fmt --all -- --check
@@ -42,13 +44,14 @@ jobs:
             -D clippy::print_stderr
 
       - name: Test
-        run: cargo test --all-features
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: wpm/KenKen
+          files: lcov.info
 
       - name: Doc
         run: cargo doc --no-deps --all-features


### PR DESCRIPTION
## Summary

- Add `llvm-tools` component to `dtolnay/rust-toolchain` so the LLVM coverage instrumentation tooling is available
- Install `cargo-llvm-cov` via `taiki-e/install-action` (pre-built binary, faster than `cargo install`)
- Replace `cargo test` with `cargo llvm-cov --lcov --output-path lcov.info` to generate an LCOV coverage report
- Pass `files: lcov.info` to `codecov/codecov-action@v5` so it finds the report

Without these changes, no coverage file is produced and Codecov fails with "No coverage reports found."

## Test plan

- [ ] CI passes on this PR (format, clippy, tests, coverage upload, docs all green)
- [ ] Codecov receives coverage data and reports a non-zero coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)