### PR TITLE
build: check in git hooks to .githooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "==> cargo fmt"
+cargo fmt --all
+git add -u
+
+echo "==> cargo clippy"
+cargo clippy --all-targets --all-features -- \
+  -D warnings \
+  -D clippy::all \
+  -D clippy::pedantic \
+  -D clippy::nursery \
+  -D clippy::unwrap_used \
+  -D clippy::expect_used \
+  -D clippy::panic \
+  -D clippy::todo \
+  -D clippy::unimplemented \
+  -D clippy::dbg_macro \
+  -D clippy::print_stdout \
+  -D clippy::print_stderr \
+  2>&1
+
+echo "==> cargo doc"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1
+
+echo "==> Pre-commit checks passed"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ into cages, each labeled with a target number and an arithmetic operation. The g
 with digits 1 through n such that no digit repeats in any row or column, and the numbers in each cage
 produce the target value using the given operation.
 
+## Development setup
+
+After cloning, configure git to use the checked-in hooks:
+
+```sh
+git config core.hooksPath .githooks
+```
+
 ## What the library provides
 
 **Generate puzzles** with `generate(n, rng)` for a random n×n puzzle, or


### PR DESCRIPTION
## Summary

- Add `.githooks/pre-commit` running `cargo fmt`, `cargo clippy`, and `cargo doc` with the same flags as CI
- Configure git to use `.githooks` via `git config core.hooksPath .githooks`
- Document the one-time setup step in README

## Test plan

- Clone the repo, run `git config core.hooksPath .githooks`, make a commit, and verify the pre-commit hook runs
- Confirm a commit with formatting or clippy violations is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)