### PR TITLE
Document precondition for regin algorithm implementation

### DIFF
--- a/src/regin.rs
+++ b/src/regin.rs
@@ -13,6 +13,21 @@ use crate::types::{N, Values};
 /// 3. Compute SCCs of the residual graph.
 /// 4. An edge (variable → value) is arc-consistent iff it is in the matching
 ///    OR both endpoints lie in the same SCC. Remove all other edges.
+///
+/// # Precondition
+///
+/// The union of the domains must contain at most `domains.len()` values
+/// (equivalently, every feasible assignment is a perfect matching that uses
+/// every value). When there are more values than variables, some values are
+/// "free" (unmatched) and the SCC-only residual graph used here isolates them
+/// in their own component, causing edges to those values to be pruned even
+/// when they participate in valid assignments. The full Régin construction
+/// fixes this by adding a sink node connected to free values; this
+/// implementation omits that step. See issue #30.
+///
+/// The only current caller (`AllDifferent::grid_value_filter`) always passes
+/// a full row or column of an `n`×`n` grid with values `{1..=n}`, so the
+/// precondition holds. New callers must ensure it before using `regin`.
 use std::collections::HashMap;
 
 #[must_use]


### PR DESCRIPTION
## Summary
Added comprehensive documentation of a critical precondition for the `regin` function that was previously undocumented, explaining when the current implementation is safe to use and what limitations exist.

## Changes
- Added a "Precondition" section to the `regin` function documentation explaining that the union of domains must contain at most `domains.len()` values
- Documented the issue that arises when there are more values than variables: free (unmatched) values get isolated in their own SCC component, causing incorrect edge pruning
- Explained that the full Régin algorithm would fix this with a sink node, but this implementation omits that optimization
- Referenced issue #30 for the known limitation
- Noted that the current caller (`AllDifferent::grid_value_filter`) always satisfies the precondition by passing full rows/columns of an n×n grid with values {1..=n}
- Added guidance for future callers to verify the precondition before using `regin`

## Implementation Details
This is purely a documentation change that clarifies the constraints and assumptions of the existing implementation without modifying any algorithmic logic. The precondition was already implicitly required by the implementation; this change makes it explicit to prevent misuse.

https://claude.ai/code/session_01PHqbD9wN84hiGxiTD1ovC1