### PR TITLE
Prepare for crates.io release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `Solver<S>` and `State` trait are now public, allowing direct solution enumeration
+  via `Solver::new(puzzle)`.
+
+### Changed
+- `M`, `Index`, and `N` type aliases removed from the public API; signatures now use
+  `u16`, `usize`, and `u8` directly.
+- `Error::FlipWouldDisconnect` renamed to `Error::WouldDisconnect`.
+
+## [0.1.0] - 2026-05-12
+
+### Added
+- `Puzzle` — core type for building and querying KenKen puzzles.
+  - `Puzzle::new(n)`, `insert_cage`, `remove_cage`
+  - `uniqueness()`, `solutions()`, `solutions_at_most(k)`
+  - `propagate_fully()`, `narrow()`, `widen()`
+  - `rank_tuples_for_cage()` with `NarrowingScore`
+  - `singleton_cells()`, `empty_cells()`, `candidates()`
+- `Cage` — a `Polyomino` paired with an `Operation`.
+  - `Cage::new(n, polyomino, operation)`
+  - `valid_operators()`, `valid_targets()`, `is_valid()`
+- `Polyomino` — a set of contiguous grid cells.
+  - `extend()`, `without()`
+- `Operation` and `Operator` enums (`Add`, `Subtract`, `Multiply`, `Divide`, `Given`).
+- `operator_tuples(n, polyomino, operator)` — enumerates all valid operations and their
+  tuples for a given operator on a polyomino.
+- `generate(n, rng)` and `generate_with(n, rng, op_policy, size_distribution)` for
+  random puzzle generation.
+- `SizeDistribution` (`Fixed`, `Uniform`) for controlling cage-size sampling.
+- `Delta` for applying candidate-domain updates to a `Puzzle`.
+- `Grid`, `Values`, `Cell` — grid and candidate-value types.
+- `Uniqueness` (`None`, `Unique`, `Multiple`) — solution-count classification.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/wpm/KenKen"
 keywords = ["kenken", "puzzle", "generator", "solver"]
 categories = ["games"]
 readme = "README.md"
+exclude = ["CLAUDE.md", ".githooks", ".github"]
 
 [dependencies]
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "kenken"
 version = "0.1.0"
 edition = "2024"
+description = "KenKen puzzle generator and solver"
+license = "MIT"
+repository = "https://github.com/wpm/KenKen"
+keywords = ["kenken", "puzzle", "generator", "solver"]
+categories = ["games"]
+readme = "README.md"
 
 [dependencies]
 itertools = "0.14.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 W.P. McNeill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ git config core.hooksPath .githooks
 - `solutions_at_most(k)` — count up to `k` solutions; useful for capping runtime when only a threshold
   matters.
 
+**Enumerate solutions** directly with `Solver::new(puzzle)`, a depth-first backtracking iterator
+that yields one solved `Puzzle` per solution.
+
 **Generate puzzles** randomly with `generate(n, rng)`, or use `generate_with(n, rng, op_policy,
 size_distribution)` to control how cage operations are assigned and how cage sizes are distributed:
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ git config core.hooksPath .githooks
 
 ## What the library provides
 
-**Generate puzzles** with `generate(n, rng)` for a random n×n puzzle, or
-`generate_with(n, rng, op_policy, size_distribution)` to control how cage operations are assigned and
-how cage sizes are distributed.
+**Build puzzles** with `Puzzle::new(n)`, then add cages via `insert_cage` and remove them via
+`remove_cage`. Each `Cage` is a `Polyomino` paired with an `Operation` (`Add`, `Subtract`,
+`Multiply`, `Divide`, or `Given`).
 
 **Query solution counts** on any `Puzzle`:
 
@@ -32,9 +32,9 @@ how cage sizes are distributed.
 - `solutions_at_most(k)` — count up to `k` solutions; useful for capping runtime when only a threshold
   matters.
 
-**Customize generation** via two named knobs:
+**Generate puzzles** randomly with `generate(n, rng)`, or use `generate_with(n, rng, op_policy,
+size_distribution)` to control how cage operations are assigned and how cage sizes are distributed:
 
-- `default_op_policy` / custom closure — maps a cage's cell values to an `Operation` (`Add`,
-  `Subtract`, `Multiply`, `Divide`, or `Given`).
+- `default_op_policy` / custom closure — maps a cage's cell values to an `Operation`.
 - `DEFAULT_SIZE_DISTRIBUTION` / `SizeDistribution` — controls cage-size sampling (`Fixed(n)` or
   `Uniform { min, max }`).

--- a/src/constraints/all_different.rs
+++ b/src/constraints/all_different.rs
@@ -1,7 +1,8 @@
 use crate::constraints::constraint::{Constraint, ValueFilter};
 use crate::constraints::regin::regin;
 use crate::geometry::shape::Cells;
-use crate::{Cell, Error, Grid, Index, Values};
+use crate::types::Index;
+use crate::{Cell, Error, Grid, Values};
 
 /// A constraint that ensures each cell in a row or column has a different value.
 #[must_use]

--- a/src/constraints/cage/arithmetic.rs
+++ b/src/constraints/cage/arithmetic.rs
@@ -2,48 +2,23 @@ use crate::constraints::cage::builder::Tuple;
 use crate::{M, N};
 
 /// Returns an iterator over all non-decreasing `k`-tuples with values in `1..=n` that sum to `s`.
-#[allow(dead_code)]
 pub fn addition_multisets(n: N, k: usize, s: N) -> impl Iterator<Item = Tuple> {
     simplex_multisets(n, k, |acc, i| acc + M::from(i), M::from(s))
 }
 
 /// Returns all 2-element tuples `[i, j]` with `j - i == d` and `1 <= i < j <= max`.
-#[allow(dead_code)]
 pub fn subtraction_multisets(max: N, d: N) -> impl Iterator<Item = Tuple> {
     (1..=max.saturating_sub(d)).map(move |i| vec![i, i + d])
 }
 
 /// Returns an iterator over all non-decreasing `k`-tuples with values in `1..=n` whose product is `s`.
-#[allow(dead_code)]
 pub fn multiplication_multisets(n: N, k: usize, s: M) -> impl Iterator<Item = Tuple> {
     simplex_multisets(n, k, |acc, i| acc * M::from(i), s)
 }
 
 /// Returns all 2-element tuples `[i, j]` with `j / i == q` and `1 <= i < j <= max`.
-#[allow(dead_code)]
 pub fn division_multisets(max: N, q: N) -> impl Iterator<Item = Tuple> {
     (1..=max / q).map(move |i| vec![i, i * q])
-}
-
-/// Returns an iterator over all non-decreasing `k`-tuples with values in `1..=n`.
-///
-/// Each tuple is a multiset drawn from `1..=n` stored in non-decreasing order. The number of
-/// tuples is the multiset coefficient C(n+k-1, k). The base case `k == 0` yields a single empty tuple.
-#[allow(dead_code)]
-fn simplex(n: N, k: usize) -> Box<dyn Iterator<Item = Tuple>> {
-    if k == 0 {
-        return Box::new(std::iter::once(vec![]));
-    }
-    Box::new(simplex(n, k - 1).flat_map(move |t| {
-        let last = t.last().copied().unwrap_or(1);
-        (last..=n)
-            .map(move |i| {
-                let mut t = t.clone();
-                t.push(i);
-                t
-            })
-            .collect::<Vec<_>>()
-    }))
 }
 
 /// Returns an iterator over all non-decreasing `tuple_size`-tuples with values in `1..=n` where
@@ -153,47 +128,6 @@ mod tests {
             division_multisets(5, 7).collect::<Vec<_>>(),
             Vec::<Tuple>::new()
         );
-    }
-
-    #[test]
-    fn simplex_k0_yields_empty_tuple() {
-        assert_eq!(simplex(3, 0).collect::<Vec<_>>(), vec![vec![]]);
-    }
-
-    #[test]
-    fn simplex_k1_yields_singletons() {
-        assert_eq!(
-            simplex(3, 1).collect::<Vec<_>>(),
-            vec![vec![1], vec![2], vec![3]]
-        );
-    }
-
-    #[test]
-    fn simplex_k2_yields_nondecreasing_pairs() {
-        assert_eq!(
-            simplex(3, 2).collect::<Vec<_>>(),
-            vec![
-                vec![1, 1],
-                vec![1, 2],
-                vec![1, 3],
-                vec![2, 2],
-                vec![2, 3],
-                vec![3, 3]
-            ]
-        );
-    }
-
-    #[test]
-    fn simplex_k3_count() {
-        // C(n+k-1, k) = C(3+3-1, 3) = C(5,3) = 10
-        assert_eq!(simplex(3, 3).count(), 10);
-    }
-
-    #[test]
-    fn simplex_tuples_are_nondecreasing() {
-        for tuple in simplex(4, 3) {
-            assert!(tuple.windows(2).all(|w| w[0] <= w[1]));
-        }
     }
 
     #[test]

--- a/src/constraints/cage/arithmetic.rs
+++ b/src/constraints/cage/arithmetic.rs
@@ -1,5 +1,5 @@
 use crate::constraints::cage::builder::Tuple;
-use crate::{M, N};
+use crate::types::{M, N};
 
 /// Returns an iterator over all non-decreasing `k`-tuples with values in `1..=n` that sum to `s`.
 pub fn addition_multisets(n: N, k: usize, s: N) -> impl Iterator<Item = Tuple> {

--- a/src/constraints/cage/builder.rs
+++ b/src/constraints/cage/builder.rs
@@ -4,8 +4,8 @@ use crate::constraints::cage::arithmetic::{
 use crate::constraints::cage::operation::{Operation, Operator};
 use crate::constraints::constraint::{Constraint, ValueFilter};
 use crate::geometry::shape::Cells;
-use crate::types::{Cell, Index};
-use crate::{Error, Grid, M, N, Polyomino, Values};
+use crate::types::{Cell, Index, M, N};
+use crate::{Error, Grid, Polyomino, Values};
 use std::collections::HashMap;
 
 /// An ordered assignment of values to the cells of a cage, one value per cell.

--- a/src/constraints/cage/builder.rs
+++ b/src/constraints/cage/builder.rs
@@ -7,9 +7,8 @@ use crate::geometry::shape::Cells;
 use crate::types::{Cell, Index};
 use crate::{Error, Grid, M, N, Polyomino, Values};
 use std::collections::HashMap;
-use strum::IntoEnumIterator;
 
-#[allow(dead_code)]
+/// An ordered assignment of values to the cells of a cage, one value per cell.
 pub type Tuple = Vec<N>;
 
 /// A polyomino constraint defined by a set of cells and an arithmetic operation.
@@ -160,20 +159,6 @@ impl Constraint for Cage {
         }
         Ok(self.cells().iter().copied().zip(cols).collect())
     }
-}
-
-/// Returns the operators for which at least one valid operation exists for the given polyomino
-/// in the context of the grid.
-///
-/// An operator is included only if [`operator_tuples`] yields at least one [`Operation`]
-/// for it — i.e. there exists some target value that is consistent with the grid constraints.
-#[allow(dead_code)]
-fn possible_operators(grid: &Grid, polyomino: &Polyomino) -> Vec<Operator> {
-    #[allow(clippy::cast_possible_truncation)]
-    let n = grid.n() as N;
-    Operator::iter()
-        .filter(|operator| !operator_tuples(n, polyomino, *operator).is_empty())
-        .collect()
 }
 
 /// Returns a map from each valid [`Operation`] to the ordered tuples that realize it, for the
@@ -404,10 +389,6 @@ mod tests {
         Polyomino::new(&cells(positions))
     }
 
-    fn grid(n: usize) -> Grid {
-        Grid::new(n).unwrap()
-    }
-
     // --- collinear_pairs ---
 
     #[test]
@@ -577,38 +558,6 @@ mod tests {
     fn operator_tuples_divide_non_pair_is_empty() {
         let p = poly(&[(0, 0), (0, 1), (0, 2)]);
         assert!(operator_tuples(4, &p, Operator::Divide).is_empty());
-    }
-
-    // --- possible_operators ---
-
-    #[test]
-    fn possible_operators_singleton() {
-        let g = grid(4);
-        let p = poly(&[(0, 0)]);
-        assert_eq!(possible_operators(&g, &p), vec![Operator::Given]);
-    }
-
-    #[test]
-    fn possible_operators_two_cell_pair_includes_all() {
-        let g = grid(4);
-        let p = poly(&[(0, 0), (0, 1)]);
-        let ops = possible_operators(&g, &p);
-        assert!(ops.contains(&Operator::Add));
-        assert!(ops.contains(&Operator::Subtract));
-        assert!(ops.contains(&Operator::Multiply));
-        assert!(ops.contains(&Operator::Divide));
-    }
-
-    #[test]
-    fn possible_operators_three_cell_line_excludes_subtract_divide_given() {
-        let g = grid(4);
-        let p = poly(&[(0, 0), (0, 1), (0, 2)]);
-        let ops = possible_operators(&g, &p);
-        assert!(ops.contains(&Operator::Add));
-        assert!(ops.contains(&Operator::Multiply));
-        assert!(!ops.contains(&Operator::Subtract));
-        assert!(!ops.contains(&Operator::Divide));
-        assert!(!ops.contains(&Operator::Given));
     }
 
     // --- Cage::new ---

--- a/src/constraints/cage/operation.rs
+++ b/src/constraints/cage/operation.rs
@@ -6,13 +6,17 @@ use strum::EnumIter;
 /// Every variant carries its target as an `M` (u16). The product target needs the wider
 /// type; the others fit in `N` but use `M`, so the API is uniform and consumers can read
 /// `target` without matching on the variant.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Operation {
+    /// Cells sum to the target.
     Add(M),
+    /// Two cells differ by the target.
     Subtract(M),
+    /// Cells multiply to the target.
     Multiply(M),
+    /// Two cells have a ratio equal to the target.
     Divide(M),
+    /// A single cell is fixed to the target value.
     Given(M),
 }
 
@@ -22,14 +26,18 @@ pub enum Operation {
 /// `Cage::valid_targets` to select an operator for which to enumerate legal targets.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, EnumIter)]
 pub enum Operator {
+    /// Cells sum to a target.
     Add,
+    /// Two cells differ by a target.
     Subtract,
+    /// Cells multiply to a target.
     Multiply,
+    /// Two cells have a ratio equal to a target.
     Divide,
+    /// A single cell is fixed to a target value.
     Given,
 }
 
-#[allow(dead_code)]
 impl Operator {
     /// Returns the operator of `operation`.
     #[must_use]

--- a/src/constraints/cage/operation.rs
+++ b/src/constraints/cage/operation.rs
@@ -1,4 +1,4 @@
-use crate::M;
+use crate::types::M;
 use strum::EnumIter;
 
 /// An arithmetic operation that defines a polyomino.

--- a/src/constraints/constraint.rs
+++ b/src/constraints/constraint.rs
@@ -80,7 +80,8 @@ impl Mul for ValueFilter {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use crate::constraints::constraint::ValueFilter;
-    use crate::{Cell, Index, Values};
+    use crate::types::Index;
+    use crate::{Cell, Values};
 
     fn filter(pairs: &[(Cell, Values)]) -> ValueFilter {
         ValueFilter(pairs.iter().copied().collect())

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1,3 +1,5 @@
+//! Core puzzle generation: assigns operations and targets to cages over a solved Latin square.
+
 use crate::Cage;
 use crate::constraints::cage::operation::Operation;
 use crate::generation::latin_square::generate_latin_square;

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -1,4 +1,4 @@
+//! Puzzle generation: Latin square construction and cage labeling.
+
 pub mod generate;
 mod latin_square;
-
-pub use generate::generate;

--- a/src/geometry/grid.rs
+++ b/src/geometry/grid.rs
@@ -51,11 +51,13 @@ impl Grid {
         self
     }
 
+    /// Returns `true` if every cell has been narrowed to a single value.
     #[must_use]
     pub fn is_solved(&self) -> bool {
         self.cells.iter().all(|values| values.is_singleton())
     }
 
+    /// Returns `true` if any cell has no remaining candidate values.
     #[must_use]
     pub fn is_invalid(&self) -> bool {
         self.cells.iter().any(|values| values.is_empty())

--- a/src/geometry/shape.rs
+++ b/src/geometry/shape.rs
@@ -74,7 +74,7 @@ impl Polyomino {
     /// # Errors
     /// - [`Error::CellNotCovered`] if `cell` is not in `self`.
     /// - [`Error::RemovalWouldEmptyPolyomino`] if `self` has only one cell.
-    /// - [`Error::FlipWouldDisconnect`] if removal leaves the remaining cells disconnected.
+    /// - [`Error::WouldDisconnect`] if removal leaves the remaining cells disconnected.
     pub fn without(&self, cell: Cell) -> Result<Self, Error> {
         if !self.contains_cell(cell) {
             return Err(Error::CellNotCovered(cell));
@@ -85,7 +85,7 @@ impl Polyomino {
         let mut remaining = self.0.clone();
         remaining.retain(|c| *c != cell);
         if !is_connected(&remaining) {
-            return Err(Error::FlipWouldDisconnect(cell));
+            return Err(Error::WouldDisconnect(cell));
         }
         Ok(Self(remaining))
     }
@@ -225,7 +225,7 @@ mod tests {
     fn without_errors_when_removal_disconnects() {
         let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1), Cell::new(0, 2)]);
         let r = p.without(Cell::new(0, 1));
-        assert!(matches!(r, Err(Error::FlipWouldDisconnect(_))));
+        assert!(matches!(r, Err(Error::WouldDisconnect(_))));
     }
 
     #[test]

--- a/src/geometry/shape.rs
+++ b/src/geometry/shape.rs
@@ -3,7 +3,7 @@
 use crate::types::{Cell, Error};
 use std::collections::HashSet;
 
-/// An arbitrary set of cells forming a polyomino, stored in sorted order without duplicates.
+/// A set of conitguous cells forming a polyomino, stored in sorted order without duplicates.
 ///
 /// `Polyomino`s are ordered by the row-major position of their upper-left-hand cell, with
 /// the remaining cells breaking ties so the order is total and consistent with `Eq`. This
@@ -32,11 +32,13 @@ impl Polyomino {
         &self.0
     }
 
+    /// Returns the number of cells in the polyomino.
     #[must_use]
     pub const fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Returns `true` if the polyomino contains no cells.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.0.is_empty()

--- a/src/geometry/tiling.rs
+++ b/src/geometry/tiling.rs
@@ -11,7 +11,12 @@ pub enum SizeDistribution {
     /// Every polyomino has the same target size.
     Fixed(usize),
     /// Target size sampled uniformly from `min..=max`.
-    Uniform { min: usize, max: usize },
+    Uniform {
+        /// Smallest allowed cage size.
+        min: usize,
+        /// Largest allowed cage size.
+        max: usize,
+    },
 }
 
 impl SizeDistribution {
@@ -50,11 +55,13 @@ impl Tiling {
         self.n
     }
 
+    /// Returns the number of polyominos in the tiling.
     #[must_use]
     pub fn len(&self) -> usize {
         self.polyominos.len()
     }
 
+    /// Returns `true` if the tiling contains no polyominos.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.polyominos.is_empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,4 @@ pub use geometry::shape::Polyomino;
 pub use geometry::tiling::SizeDistribution;
 pub use puzzle::{NarrowingScore, Puzzle, Uniqueness};
 pub use solver::delta::Delta;
-pub use types::{Cell, Error, Index, M, N, Values};
+pub use types::{Cell, Error, Values};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 //! [`Puzzle::insert_cage`], and inspect solutions with [`Puzzle::uniqueness`] and
 //! [`Puzzle::solutions`].
 //!
+//! For direct enumeration of solutions, [`Solver`] is a depth-first backtracking iterator
+//! over any type that implements [`State`]; [`Puzzle`] implements [`State`].
+//!
 //! Puzzles can also be generated randomly via [`generate()`] or [`generate_with`].
 
 mod constraints;
@@ -23,4 +26,5 @@ pub use geometry::shape::Polyomino;
 pub use geometry::tiling::SizeDistribution;
 pub use puzzle::{NarrowingScore, Puzzle, Uniqueness};
 pub use solver::delta::Delta;
+pub use solver::solve::{Solver, State};
 pub use types::{Cell, Error, Values};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,22 @@
-pub(crate) mod constraints;
+//! KenKen puzzle generator and solver.
+//!
+//! The primary interface is [`Puzzle`]: construct one with [`Puzzle::new`], add [`Cage`]s via
+//! [`Puzzle::insert_cage`], and inspect solutions with [`Puzzle::uniqueness`] and
+//! [`Puzzle::solutions`].
+//!
+//! Puzzles can also be generated randomly via [`generate()`] or [`generate_with`].
+
+mod constraints;
 mod generation;
-pub(crate) mod geometry;
+mod geometry;
 mod puzzle;
-pub(crate) mod solver;
+mod solver;
 mod types;
 
 pub use constraints::cage::builder::{Cage, Tuple};
 pub use constraints::cage::operation::{Operation, Operator};
 pub use constraints::cage::operator_tuples;
-pub use generation::generate;
+pub use generation::generate::generate;
 pub use generation::generate::{DEFAULT_SIZE_DISTRIBUTION, default_op_policy, generate_with};
 pub use geometry::grid::Grid;
 pub use geometry::shape::Polyomino;

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -1,16 +1,23 @@
-#![allow(dead_code)]
-
+/// A search state that can be propagated to a fixed point and branched into sub-states.
 pub trait State: Sized {
+    /// Applies constraint propagation, returning `None` if the state is invalid.
     fn propagate(self) -> Option<Self>;
+    /// Returns an iterator over branched sub-states. An empty iterator signals a solution.
     fn branch(self) -> impl Iterator<Item = Self>;
 }
 
+/// A depth-first backtracking solver over any [`State`].
+///
+/// Each call to [`Iterator::next`] returns one solution — a state for which [`State::branch`]
+/// yields no children. [`Puzzle`](crate::Puzzle) implements [`State`], so `Solver<Puzzle>`
+/// enumerates all solutions to a puzzle.
 #[must_use]
 pub struct Solver<S> {
     stack: Vec<S>,
 }
 
 impl<S: State> Solver<S> {
+    /// Creates a new solver starting from `root`.
     pub fn new(root: S) -> Self {
         Self { stack: vec![root] }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,11 +13,14 @@ pub type M = u16;
 #[must_use]
 #[derive(Ord, Eq, PartialEq, PartialOrd, Debug, Copy, Clone, Hash)]
 pub struct Cell {
+    /// 0-based row index.
     pub row: Index,
+    /// 0-based column index.
     pub column: Index,
 }
 
 impl Cell {
+    /// Creates a cell at the given `row` and `column`.
     pub const fn new(row: Index, column: Index) -> Self {
         Self { row, column }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -130,7 +130,7 @@ pub enum Error {
     CellNotCovered(Cell),
     /// Removing a cell from a polyomino would leave the remaining cells disconnected.
     /// Raised by `Polyomino::without`.
-    FlipWouldDisconnect(Cell),
+    WouldDisconnect(Cell),
     /// A target cell is not 4-adjacent to any cell of the polyomino it was applied to.
     TargetNotAdjacent,
     /// A cell passed to `Polyomino::extend` is already in the polyomino.

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -4,8 +4,8 @@
 #![allow(clippy::unwrap_used)]
 
 use kenken::{
-    Cage, Cell, DEFAULT_SIZE_DISTRIBUTION, Delta, Grid, Index, N, NarrowingScore, Operation,
-    Operator, Polyomino, Puzzle, SizeDistribution, Uniqueness, Values, default_op_policy, generate,
+    Cage, Cell, DEFAULT_SIZE_DISTRIBUTION, Delta, Grid, NarrowingScore, Operation, Operator,
+    Polyomino, Puzzle, SizeDistribution, Uniqueness, Values, default_op_policy, generate,
     generate_with,
 };
 use rand::SeedableRng;
@@ -104,7 +104,7 @@ fn uniqueness_and_solutions_buckets_agree() {
 
 #[test]
 fn custom_op_policy_overrides_default() {
-    let policy = |values: &[N], n: Index| {
+    let policy = |values: &[u8], n: usize| {
         if values.len() == 2 {
             Operation::Add(values.iter().map(|&v| u16::from(v)).sum())
         } else {
@@ -157,7 +157,7 @@ fn size_distribution_uniform_is_constructible() {
     assert_ne!(p.uniqueness(), Uniqueness::None);
 }
 
-fn given_cage(row: Index, column: Index, value: N) -> Cage {
+fn given_cage(row: usize, column: usize, value: u8) -> Cage {
     let cell = Cell::new(row, column);
     Cage::new(
         value,
@@ -223,7 +223,7 @@ fn fresh_puzzle_has_no_singletons_or_empty_cells() {
 fn singleton_grid_yields_its_only_cell() {
     // 1×1: the lone cell holds {1}, which is a singleton by construction.
     let p = Puzzle::new(1).unwrap();
-    let singletons: Vec<(Cell, N)> = p.singleton_cells().collect();
+    let singletons: Vec<(Cell, u8)> = p.singleton_cells().collect();
     assert_eq!(singletons, vec![(Cell::new(0, 0), 1)]);
 }
 
@@ -257,8 +257,8 @@ fn rank_tuples_for_cage_is_public_and_returns_scored_entries() {
     let cells = [Cell::new(0, 0), Cell::new(0, 1)];
     let cage = Cage::new(4, Polyomino::new(&cells), Operation::Add(3));
     let p = Puzzle::new(4).unwrap().insert_cage(cage.clone()).unwrap();
-    let ranked: Vec<(Vec<N>, Puzzle, NarrowingScore)> = p.rank_tuples_for_cage(&cage).unwrap();
-    let tuples: Vec<Vec<N>> = ranked.iter().map(|(t, _, _)| t.clone()).collect();
+    let ranked: Vec<(Vec<u8>, Puzzle, NarrowingScore)> = p.rank_tuples_for_cage(&cage).unwrap();
+    let tuples: Vec<Vec<u8>> = ranked.iter().map(|(t, _, _)| t.clone()).collect();
     assert_eq!(tuples, vec![vec![1, 2], vec![2, 1]]);
     assert!(ranked.iter().all(|(_, post, _)| post.is_valid()));
     let score: NarrowingScore = ranked[0].2;

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -5,7 +5,7 @@
 
 use kenken::{
     Cage, Cell, DEFAULT_SIZE_DISTRIBUTION, Delta, Grid, NarrowingScore, Operation, Operator,
-    Polyomino, Puzzle, SizeDistribution, Uniqueness, Values, default_op_policy, generate,
+    Polyomino, Puzzle, SizeDistribution, Solver, Uniqueness, Values, default_op_policy, generate,
     generate_with,
 };
 use rand::SeedableRng;
@@ -364,4 +364,55 @@ fn delta_narrow_widen_and_propagate_fully_are_public() {
         rewidened.candidates(Cell::new(1, 1)).unwrap(),
         Values::new([1]),
     );
+}
+
+#[test]
+fn solve_simple_2x2_puzzle() {
+    // 2×2 grid with two Add(3) cages, one per row.
+    //
+    //   ┌───────┐
+    //   │  3+   │  (0,0)+(0,1)
+    //   ├───────┤
+    //   │  3+   │  (1,0)+(1,1)
+    //   └───────┘
+    //
+    // Both rows must contain {1,2}; all-different columns give exactly two solutions:
+    //   [[1,2],[2,1]]  and  [[2,1],[1,2]]
+    let p = Puzzle::new(2)
+        .unwrap()
+        .insert_cage(Cage::new(
+            2,
+            Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]),
+            Operation::Add(3),
+        ))
+        .unwrap()
+        .insert_cage(Cage::new(
+            2,
+            Polyomino::new(&[Cell::new(1, 0), Cell::new(1, 1)]),
+            Operation::Add(3),
+        ))
+        .unwrap();
+
+    let solutions: Vec<Puzzle> = Solver::new(p).collect();
+    assert_eq!(solutions.len(), 2);
+    for solution in &solutions {
+        assert_eq!(solution.singleton_cells().count(), 4);
+    }
+
+    let mut grids: Vec<Vec<u8>> = solutions
+        .iter()
+        .map(|s| {
+            [
+                Cell::new(0, 0),
+                Cell::new(0, 1),
+                Cell::new(1, 0),
+                Cell::new(1, 1),
+            ]
+            .iter()
+            .map(|c| s.singleton_cells().find(|(cell, _)| cell == c).unwrap().1)
+            .collect()
+        })
+        .collect();
+    grids.sort();
+    assert_eq!(grids, vec![vec![1, 2, 2, 1], vec![2, 1, 1, 2]]);
 }


### PR DESCRIPTION
## Summary

- Add crates.io metadata to `Cargo.toml` (description, license, repository, keywords, categories) and MIT `LICENSE` file
- Tighten public API: all internal modules are private; `M`, `Index`, and `N` type aliases removed from public surface (signatures use `u16`, `usize`, `u8` directly)
- Expose `Solver<S>` and `State` trait publicly for direct solution enumeration
- Document all public items; zero `missing-docs` warnings
- Add `CHANGELOG.md`
- Exclude `CLAUDE.md`, `.githooks`, `.github` from published package
- Rename `Error::FlipWouldDisconnect` → `Error::WouldDisconnect`
- Delete unused `simplex()` and `possible_operators()` functions and their tests
- Remove all `#[allow(dead_code)]` suppressions
- Add `solve_simple_2x2_puzzle` integration test using `Solver`
- Update README to lead with `Puzzle` construction and mention solving

## Test plan

- [x] `cargo test` passes (232 tests)
- [x] `RUSTDOCFLAGS="-W missing-docs" cargo doc --no-deps` produces zero warnings
- [x] `cargo publish --dry-run` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)