### PR TITLE
Document no-direct-main-branch rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,4 +3,5 @@
 - After making a pull request, run `/review` on it.
   - Write the review contents to the pull request.
 - Monitor pull requests for source conflicts and CI failures. Fix them.
+- Never work directly on the `main` branch. Also use a feature branch.
 - Use an isolated worktree when working locally.


### PR DESCRIPTION
## Summary

- Add instruction to CLAUDE.md: never work directly on `main`, always use a feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)