### PR TITLE
chore: add lcov.info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+lcov.info
 .claude/


### PR DESCRIPTION
`lcov.info` is a generated coverage artifact written by `cargo llvm-cov`. It shouldn't be checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)