### PR TITLE
feat: improve public API — Result returns, re-exports, and error variants

### DIFF
--- a/src/constraints/all_different.rs
+++ b/src/constraints/all_different.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Cell, Fill,
+    Cell, Error, Fill,
     constraints::{Constraint, RegionConstraint, cover::Cover, regin::regin},
     grid::Grid,
 };
@@ -12,19 +12,25 @@ pub struct AllDifferent(Vec<Cell>);
 
 impl AllDifferent {
     /// A row of [`Cell`]s that must all have a different value.
-    /// # Panics
-    /// Panics if `n` is zero.
-    pub fn row(n: usize, index: usize) -> Self {
-        assert!(n > 0);
-        Self((0..n).map(|column| Cell::new(index, column)).collect())
+    /// # Errors
+    /// Returns [`Error::IndexOutOfRange`] if `index` is not less than `n`.
+    pub fn row(n: usize, index: usize) -> Result<Self, Error> {
+        if index >= n {
+            return Err(Error::IndexOutOfRange(index, n));
+        }
+        Ok(Self(
+            (0..n).map(|column| Cell::new(index, column)).collect(),
+        ))
     }
 
     /// A column of [`Cell`]s that must all have a different value.
-    /// # Panics
-    /// Panics if `n` is zero.
-    pub fn column(n: usize, index: usize) -> Self {
-        assert!(n > 0);
-        Self((0..n).map(|row| Cell::new(row, index)).collect())
+    /// # Errors
+    /// Returns [`Error::IndexOutOfRange`] if `index` is not less than `n`.
+    pub fn column(n: usize, index: usize) -> Result<Self, Error> {
+        if index >= n {
+            return Err(Error::IndexOutOfRange(index, n));
+        }
+        Ok(Self((0..n).map(|row| Cell::new(row, index)).collect()))
     }
 }
 
@@ -52,17 +58,18 @@ impl RegionConstraint for AllDifferent {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     // --- Region::row ---
 
     use crate::{
-        Cell,
+        Cell, Error,
         constraints::{all_different::AllDifferent, cover::Cover},
     };
 
     #[test]
     fn row_contains_correct_cells() {
-        let r = AllDifferent::row(4, 2);
+        let r = AllDifferent::row(4, 2).unwrap();
         assert_eq!(
             r.cells(),
             vec![
@@ -75,16 +82,30 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn row_panics_on_zero_n() {
-        let _ = AllDifferent::row(0, 0);
+    fn row_zero_n_returns_err() {
+        assert!(matches!(
+            AllDifferent::row(0, 0),
+            Err(Error::IndexOutOfRange(0, 0))
+        ));
+    }
+
+    #[test]
+    fn row_index_ge_n_returns_err() {
+        assert!(matches!(
+            AllDifferent::row(3, 3),
+            Err(Error::IndexOutOfRange(3, 3))
+        ));
+        assert!(matches!(
+            AllDifferent::row(3, 5),
+            Err(Error::IndexOutOfRange(5, 3))
+        ));
     }
 
     // --- Region::column ---
 
     #[test]
     fn column_contains_correct_cells() {
-        let r = AllDifferent::column(3, 1);
+        let r = AllDifferent::column(3, 1).unwrap();
         assert_eq!(
             r.cells(),
             vec![Cell::new(0, 1), Cell::new(1, 1), Cell::new(2, 1)]
@@ -92,14 +113,28 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn column_panics_on_zero_n() {
-        let _ = AllDifferent::column(0, 0);
+    fn column_zero_n_returns_err() {
+        assert!(matches!(
+            AllDifferent::column(0, 0),
+            Err(Error::IndexOutOfRange(0, 0))
+        ));
+    }
+
+    #[test]
+    fn column_index_ge_n_returns_err() {
+        assert!(matches!(
+            AllDifferent::column(3, 3),
+            Err(Error::IndexOutOfRange(3, 3))
+        ));
+        assert!(matches!(
+            AllDifferent::column(3, 5),
+            Err(Error::IndexOutOfRange(5, 3))
+        ));
     }
 
     #[test]
     fn len_equals_n() {
-        assert_eq!(AllDifferent::row(4, 0).len(), 4);
-        assert_eq!(AllDifferent::column(3, 1).len(), 3);
+        assert_eq!(AllDifferent::row(4, 0).unwrap().len(), 4);
+        assert_eq!(AllDifferent::column(3, 1).unwrap().len(), 3);
     }
 }

--- a/src/constraints/all_different.rs
+++ b/src/constraints/all_different.rs
@@ -81,24 +81,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn row_zero_n_returns_err() {
-        assert!(matches!(
-            AllDifferent::row(0, 0),
-            Err(Error::IndexOutOfRange(0, 0))
-        ));
+    fn assert_index_out_of_range(f: impl Fn(usize, usize) -> Result<AllDifferent, Error>) {
+        assert!(matches!(f(0, 0), Err(Error::IndexOutOfRange(0, 0))));
+        assert!(matches!(f(3, 3), Err(Error::IndexOutOfRange(3, 3))));
+        assert!(matches!(f(3, 5), Err(Error::IndexOutOfRange(5, 3))));
     }
 
     #[test]
-    fn row_index_ge_n_returns_err() {
-        assert!(matches!(
-            AllDifferent::row(3, 3),
-            Err(Error::IndexOutOfRange(3, 3))
-        ));
-        assert!(matches!(
-            AllDifferent::row(3, 5),
-            Err(Error::IndexOutOfRange(5, 3))
-        ));
+    fn row_index_out_of_range_returns_err() {
+        assert_index_out_of_range(AllDifferent::row);
     }
 
     // --- Region::column ---
@@ -113,23 +104,8 @@ mod tests {
     }
 
     #[test]
-    fn column_zero_n_returns_err() {
-        assert!(matches!(
-            AllDifferent::column(0, 0),
-            Err(Error::IndexOutOfRange(0, 0))
-        ));
-    }
-
-    #[test]
-    fn column_index_ge_n_returns_err() {
-        assert!(matches!(
-            AllDifferent::column(3, 3),
-            Err(Error::IndexOutOfRange(3, 3))
-        ));
-        assert!(matches!(
-            AllDifferent::column(3, 5),
-            Err(Error::IndexOutOfRange(5, 3))
-        ));
+    fn column_index_out_of_range_returns_err() {
+        assert_index_out_of_range(AllDifferent::column);
     }
 
     #[test]

--- a/src/constraints/cage/builder.rs
+++ b/src/constraints/cage/builder.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    Fill, Operation, Operator,
+    Error, Fill, Operation, Operator,
     constraints::{
         Constraint, RegionConstraint,
         cage::arithmetic::{
@@ -86,21 +86,22 @@ impl Cage {
     ///
     /// If `op` is not in [`Self::valid_operators`] for `cells`, the iterator is
     /// empty.
-    #[must_use]
+    ///
+    /// # Errors
+    /// Returns [`Error::EmptyPolyomino`] or [`Error::DisconnectedPolyomino`] if
+    /// `cells` do not form a valid polyomino.
     pub fn valid_targets(
         cells: &[Cell],
         op: Operator,
         n: N,
-    ) -> Box<dyn Iterator<Item = Operation>> {
+    ) -> Result<Box<dyn Iterator<Item = Operation>>, Error> {
         if !Self::valid_operators(cells).contains(&op) {
-            return Box::new(std::iter::empty());
+            return Ok(Box::new(std::iter::empty()));
         }
-        let Ok(polyomino) = Polyomino::new(cells) else {
-            return Box::new(std::iter::empty());
-        };
+        let polyomino = Polyomino::new(cells)?;
         let k = polyomino.len();
         let n_m = M::from(n);
-        match op {
+        Ok(match op {
             Operator::Given => Box::new((1..=n_m).map(Operation::Given)),
             Operator::Subtract => Box::new((1..=n_m.saturating_sub(1)).map(Operation::Subtract)),
             Operator::Divide => Box::new((2..=n_m).map(Operation::Divide)),
@@ -119,7 +120,7 @@ impl Cage {
                     has_admissible_tuple(n, &polyomino, op).then_some(op)
                 }))
             }
-        }
+        })
     }
 
     /// Returns true if `operation` is legal for a cage of the given cells on an
@@ -128,20 +129,21 @@ impl Cage {
     /// The operator must be in [`Self::valid_operators`] for the cell count,
     /// the target must be in its conventional range, and at least one tuple
     /// must survive collinearity filtering.
-    #[must_use]
-    pub fn is_valid(cells: &[Cell], operation: Operation, n: N) -> bool {
+    ///
+    /// # Errors
+    /// Returns [`Error::EmptyPolyomino`] or [`Error::DisconnectedPolyomino`] if
+    /// `cells` do not form a valid polyomino.
+    pub fn is_valid(cells: &[Cell], operation: Operation, n: N) -> Result<bool, Error> {
         if !Self::valid_operators(cells).contains(&Operator::of(operation)) {
-            return false;
+            return Ok(false);
         }
         match operation {
-            Operation::Given(v) => return (1..=M::from(n)).contains(&v),
-            Operation::Subtract(0) | Operation::Divide(0 | 1) => return false,
+            Operation::Given(v) => return Ok((1..=M::from(n)).contains(&v)),
+            Operation::Subtract(0) | Operation::Divide(0 | 1) => return Ok(false),
             _ => {}
         }
-        let Ok(polyomino) = Polyomino::new(cells) else {
-            return false;
-        };
-        has_admissible_tuple(n, &polyomino, operation)
+        let polyomino = Polyomino::new(cells)?;
+        Ok(has_admissible_tuple(n, &polyomino, operation))
     }
 }
 
@@ -671,33 +673,33 @@ mod tests {
     #[test]
     fn cage_is_valid_singleton_given_in_range() {
         let cells = cells(&[(0, 0)]);
-        assert!(Cage::is_valid(&cells, Operation::Given(1), 5));
-        assert!(Cage::is_valid(&cells, Operation::Given(5), 5));
-        assert!(!Cage::is_valid(&cells, Operation::Given(0), 5));
-        assert!(!Cage::is_valid(&cells, Operation::Given(6), 5));
+        assert!(Cage::is_valid(&cells, Operation::Given(1), 5).unwrap());
+        assert!(Cage::is_valid(&cells, Operation::Given(5), 5).unwrap());
+        assert!(!Cage::is_valid(&cells, Operation::Given(0), 5).unwrap());
+        assert!(!Cage::is_valid(&cells, Operation::Given(6), 5).unwrap());
     }
 
     #[test]
     fn cage_is_valid_two_cell_subtract_zero_rejected() {
         let cs = cells(&[(0, 0), (0, 1)]);
-        assert!(!Cage::is_valid(&cs, Operation::Subtract(0), 5));
-        assert!(Cage::is_valid(&cs, Operation::Subtract(1), 5));
+        assert!(!Cage::is_valid(&cs, Operation::Subtract(0), 5).unwrap());
+        assert!(Cage::is_valid(&cs, Operation::Subtract(1), 5).unwrap());
     }
 
     #[test]
     fn cage_is_valid_two_cell_divide_below_two_rejected() {
         let cs = cells(&[(0, 0), (0, 1)]);
-        assert!(!Cage::is_valid(&cs, Operation::Divide(0), 5));
-        assert!(!Cage::is_valid(&cs, Operation::Divide(1), 5));
-        assert!(Cage::is_valid(&cs, Operation::Divide(2), 5));
+        assert!(!Cage::is_valid(&cs, Operation::Divide(0), 5).unwrap());
+        assert!(!Cage::is_valid(&cs, Operation::Divide(1), 5).unwrap());
+        assert!(Cage::is_valid(&cs, Operation::Divide(2), 5).unwrap());
     }
 
     #[test]
     fn cage_is_valid_same_row_add_rejects_double() {
         // Sum 2 requires [1,1] which is filtered by row collinearity.
         let cs = cells(&[(0, 0), (0, 1)]);
-        assert!(!Cage::is_valid(&cs, Operation::Add(2), 4));
-        assert!(Cage::is_valid(&cs, Operation::Add(3), 4));
+        assert!(!Cage::is_valid(&cs, Operation::Add(2), 4).unwrap());
+        assert!(Cage::is_valid(&cs, Operation::Add(3), 4).unwrap());
     }
 
     #[test]
@@ -706,7 +708,16 @@ mod tests {
         // so [1,2,1] (sum=4) is legal — the repeated 1 is only across a non-collinear
         // pair.
         let cs = cells(&[(0, 0), (0, 1), (1, 0)]);
-        assert!(Cage::is_valid(&cs, Operation::Add(4), 4));
+        assert!(Cage::is_valid(&cs, Operation::Add(4), 4).unwrap());
+    }
+
+    #[test]
+    fn cage_is_valid_disconnected_cells_returns_err() {
+        let cs = cells(&[(0, 0), (1, 1)]);
+        assert!(matches!(
+            Cage::is_valid(&cs, Operation::Add(3), 4),
+            Err(Error::DisconnectedPolyomino)
+        ));
     }
 
     #[test]
@@ -719,14 +730,27 @@ mod tests {
         // Given is only valid for 1-cell cages; called on a 2-cell shape, returns
         // empty.
         let cs = cells(&[(0, 0), (0, 1)]);
-        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Given, 4).collect();
+        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Given, 4)
+            .unwrap()
+            .collect();
         assert!(got.is_empty());
+    }
+
+    #[test]
+    fn valid_targets_disconnected_cells_returns_err() {
+        let cs = cells(&[(0, 0), (1, 1)]);
+        assert!(matches!(
+            Cage::valid_targets(&cs, Operator::Add, 4),
+            Err(Error::DisconnectedPolyomino)
+        ));
     }
 
     #[test]
     fn valid_targets_given_singleton_enumerates_one_through_n() {
         let cs = cells(&[(0, 0)]);
-        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Given, 4).collect();
+        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Given, 4)
+            .unwrap()
+            .collect();
         assert_eq!(
             got,
             vec![
@@ -741,7 +765,9 @@ mod tests {
     #[test]
     fn valid_targets_subtract_pair_enumerates_one_through_n_minus_one() {
         let cs = cells(&[(0, 0), (0, 1)]);
-        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Subtract, 4).collect();
+        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Subtract, 4)
+            .unwrap()
+            .collect();
         assert_eq!(
             got,
             vec![
@@ -755,7 +781,9 @@ mod tests {
     #[test]
     fn valid_targets_divide_pair_enumerates_two_through_n() {
         let cs = cells(&[(0, 0), (0, 1)]);
-        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Divide, 4).collect();
+        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Divide, 4)
+            .unwrap()
+            .collect();
         assert_eq!(
             got,
             vec![
@@ -770,7 +798,9 @@ mod tests {
     fn valid_targets_add_pair_filters_by_admissibility() {
         // n=4, 2-cell same row: Add(2) requires [1,1] which violates collinearity.
         let cs = cells(&[(0, 0), (0, 1)]);
-        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Add, 4).collect();
+        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Add, 4)
+            .unwrap()
+            .collect();
         assert!(!got.contains(&Operation::Add(2)));
         assert!(got.contains(&Operation::Add(3)));
         assert!(got.contains(&Operation::Add(7)));
@@ -780,7 +810,9 @@ mod tests {
     fn valid_targets_multiply_pair_filters_by_admissibility() {
         // n=4, 2-cell same row: Multiply(1) requires [1,1] which violates collinearity.
         let cs = cells(&[(0, 0), (0, 1)]);
-        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Multiply, 4).collect();
+        let got: Vec<Operation> = Cage::valid_targets(&cs, Operator::Multiply, 4)
+            .unwrap()
+            .collect();
         assert!(!got.contains(&Operation::Multiply(1)));
         assert!(got.contains(&Operation::Multiply(2)));
     }
@@ -831,9 +863,9 @@ mod tests {
     #[test]
     fn cage_is_valid_three_cells_rejects_subtract_and_divide() {
         let cs = cells(&[(0, 0), (0, 1), (0, 2)]);
-        assert!(!Cage::is_valid(&cs, Operation::Subtract(1), 5));
-        assert!(!Cage::is_valid(&cs, Operation::Divide(2), 5));
-        assert!(Cage::is_valid(&cs, Operation::Add(6), 5));
-        assert!(Cage::is_valid(&cs, Operation::Multiply(6), 5));
+        assert!(!Cage::is_valid(&cs, Operation::Subtract(1), 5).unwrap());
+        assert!(!Cage::is_valid(&cs, Operation::Divide(2), 5).unwrap());
+        assert!(Cage::is_valid(&cs, Operation::Add(6), 5).unwrap());
+        assert!(Cage::is_valid(&cs, Operation::Multiply(6), 5).unwrap());
     }
 }

--- a/src/constraints/cage/builder.rs
+++ b/src/constraints/cage/builder.rs
@@ -95,7 +95,9 @@ impl Cage {
         if !Self::valid_operators(cells).contains(&op) {
             return Box::new(std::iter::empty());
         }
-        let polyomino = Polyomino::new(cells);
+        let Ok(polyomino) = Polyomino::new(cells) else {
+            return Box::new(std::iter::empty());
+        };
         let k = polyomino.len();
         let n_m = M::from(n);
         match op {
@@ -136,7 +138,9 @@ impl Cage {
             Operation::Subtract(0) | Operation::Divide(0 | 1) => return false,
             _ => {}
         }
-        let polyomino = Polyomino::new(cells);
+        let Ok(polyomino) = Polyomino::new(cells) else {
+            return false;
+        };
         has_admissible_tuple(n, &polyomino, operation)
     }
 }
@@ -407,13 +411,13 @@ mod tests {
     #[test]
     fn collinear_pairs_single_cell_is_empty() {
         let positions = &[(0, 0)];
-        assert!(collinear_pairs(&Polyomino::new(&cells(positions))).is_empty());
+        assert!(collinear_pairs(&Polyomino::new(&cells(positions)).unwrap()).is_empty());
     }
 
     #[test]
     fn collinear_pairs_same_row() {
         let positions = &[(0, 0), (0, 1), (0, 2)];
-        let mut pairs = collinear_pairs(&Polyomino::new(&cells(positions)));
+        let mut pairs = collinear_pairs(&Polyomino::new(&cells(positions)).unwrap());
         pairs.sort_unstable();
         assert_eq!(pairs, vec![(0, 1), (0, 2), (1, 2)]);
     }
@@ -421,7 +425,7 @@ mod tests {
     #[test]
     fn collinear_pairs_same_column() {
         let positions = &[(0, 0), (1, 0)];
-        let mut pairs = collinear_pairs(&Polyomino::new(&cells(positions)));
+        let mut pairs = collinear_pairs(&Polyomino::new(&cells(positions)).unwrap());
         pairs.sort_unstable();
         assert_eq!(pairs, vec![(0, 1)]);
     }
@@ -430,7 +434,7 @@ mod tests {
     fn collinear_pairs_l_shape() {
         // (0,0), (1,0), (1,1): col-0 gives (0,1); row-1 gives (1,2).
         let positions = &[(0, 0), (1, 0), (1, 1)];
-        let mut pairs = collinear_pairs(&Polyomino::new(&cells(positions)));
+        let mut pairs = collinear_pairs(&Polyomino::new(&cells(positions)).unwrap());
         pairs.sort_unstable();
         assert_eq!(pairs, vec![(0, 1), (1, 2)]);
     }
@@ -488,7 +492,7 @@ mod tests {
     #[test]
     fn operator_tuples_given_singleton() {
         let positions = &[(0, 0)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let map = operator_tuples(4, &p, Operator::Given);
         assert_eq!(map.len(), 4);
         assert_eq!(map[&Operation::Given(1)], vec![vec![1]]);
@@ -498,14 +502,14 @@ mod tests {
     #[test]
     fn operator_tuples_given_non_singleton_is_empty() {
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         assert!(operator_tuples(4, &p, Operator::Given).is_empty());
     }
 
     #[test]
     fn operator_tuples_subtract_non_pair_is_empty() {
         let positions = &[(0, 0), (0, 1), (0, 2)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         assert!(operator_tuples(4, &p, Operator::Subtract).is_empty());
     }
 
@@ -513,7 +517,7 @@ mod tests {
     fn operator_tuples_subtract_pair_same_row() {
         // Same row: (1,2) gives diff=1 → both orderings [1,2] and [2,1].
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let map = operator_tuples(4, &p, Operator::Subtract);
         let mut t = map[&Operation::Subtract(1)].clone();
         t.sort();
@@ -525,7 +529,7 @@ mod tests {
     fn operator_tuples_add_same_row_excludes_doubles() {
         // n=4, same-row 2-cell: Add(2) requires [1,1] which violates collinearity.
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let map = operator_tuples(4, &p, Operator::Add);
         assert!(!map.contains_key(&Operation::Add(2)));
         assert!(map.contains_key(&Operation::Add(3)));
@@ -534,7 +538,7 @@ mod tests {
     #[test]
     fn operator_tuples_multiply_same_row() {
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let map = operator_tuples(4, &p, Operator::Multiply);
         // 1*4, 2*3, etc. allowed; squares (1*1, 2*2, 3*3) filtered by row collinearity.
         assert!(map.contains_key(&Operation::Multiply(6)));
@@ -546,7 +550,7 @@ mod tests {
     #[test]
     fn operator_tuples_divide_non_pair_is_empty() {
         let positions = &[(0, 0), (0, 1), (0, 2)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         assert!(operator_tuples(4, &p, Operator::Divide).is_empty());
     }
 
@@ -555,7 +559,7 @@ mod tests {
     #[test]
     fn cage_new_given_singleton() {
         let positions = &[(0, 0)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let cage = Cage::new(4, p, Operation::Given(3));
         assert_eq!(cage.tuples(), &[vec![3u8]]);
     }
@@ -564,7 +568,7 @@ mod tests {
     fn cage_new_subtract_same_row_pair() {
         // Same-row pair: both orderings still survive since values differ.
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let cage = Cage::new(4, p, Operation::Subtract(1));
         let mut tuples = cage.tuples().to_vec();
         tuples.sort_unstable();
@@ -586,7 +590,7 @@ mod tests {
     fn cage_new_divide_same_row_pair() {
         // Divide(2) on a same-row pair: [1,2] and [2,4] → both orderings each.
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let cage = Cage::new(4, p, Operation::Divide(2));
         let mut tuples = cage.tuples().to_vec();
         tuples.sort_unstable();
@@ -601,7 +605,7 @@ mod tests {
         // Multiply(6) on a same-row pair: multisets [1,6] and [2,3] → both orderings
         // each.
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let cage = Cage::new(6, p, Operation::Multiply(6));
         let mut tuples = cage.tuples().to_vec();
         tuples.sort_unstable();
@@ -616,7 +620,7 @@ mod tests {
         // Add(6) on same-row pair: [2,4],[4,2],[3,3] — [3,3] filtered by row
         // collinearity.
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let cage = Cage::new(4, p, Operation::Add(6));
         let mut tuples = cage.tuples().to_vec();
         tuples.sort_unstable();
@@ -628,7 +632,7 @@ mod tests {
         // (0,0),(1,0),(1,1): col-0 pair (0,1), row-1 pair (1,2).
         // 10 raw permutations from {1,1,4},{1,2,3},{2,2,2} → 7 survive.
         let positions = &[(0, 0), (1, 0), (1, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let cage = Cage::new(4, p, Operation::Add(6));
         assert_eq!(cage.tuples().len(), 7);
         assert!(!cage.tuples().contains(&vec![1u8, 1, 4]));
@@ -784,7 +788,7 @@ mod tests {
     #[test]
     fn cage_cells_via_trait_returns_same_as_inherent() {
         let positions = &[(0, 0), (0, 1)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         let cage = Cage::new(4, p, Operation::Add(3));
         let via_trait: Vec<Cell> = <Cage as Cover>::cells(&cage);
         assert_eq!(via_trait, cage.cells());
@@ -793,14 +797,14 @@ mod tests {
     #[test]
     fn operator_tuples_add_singleton_is_empty() {
         let positions = &[(0, 0)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         assert!(operator_tuples(4, &p, Operator::Add).is_empty());
     }
 
     #[test]
     fn operator_tuples_multiply_singleton_is_empty() {
         let positions = &[(0, 0)];
-        let p = Polyomino::new(&cells(positions));
+        let p = Polyomino::new(&cells(positions)).unwrap();
         assert!(operator_tuples(4, &p, Operator::Multiply).is_empty());
     }
 
@@ -808,11 +812,11 @@ mod tests {
     fn cage_new_with_target_above_n_max_yields_no_tuples() {
         let singleton = || {
             let positions = &[(0, 0)];
-            Polyomino::new(&cells(positions))
+            Polyomino::new(&cells(positions)).unwrap()
         };
         let pair = || {
             let positions = &[(0, 0), (0, 1)];
-            Polyomino::new(&cells(positions))
+            Polyomino::new(&cells(positions)).unwrap()
         };
         for (p, op) in [
             (singleton(), Operation::Given(300)),

--- a/src/constraints/cover.rs
+++ b/src/constraints/cover.rs
@@ -1,4 +1,4 @@
-use crate::Cell;
+use crate::{Cell, Error};
 
 /// A set of [`Cell`]s.
 pub trait Cover {
@@ -18,19 +18,35 @@ pub trait Cover {
 pub struct Polyomino(Vec<Cell>);
 
 impl Polyomino {
-    /// # Panics
-    /// Panics if `cells` is empty or not edge-connected.
-    pub fn new(cells: &[Cell]) -> Self {
-        assert!(!cells.is_empty() && is_edge_connected_component(cells));
+    /// # Errors
+    /// Returns [`Error::EmptyPolyomino`] if `cells` is empty, or
+    /// [`Error::DisconnectedPolyomino`] if `cells` is not edge-connected.
+    pub fn new(cells: &[Cell]) -> Result<Self, Error> {
+        if cells.is_empty() {
+            return Err(Error::EmptyPolyomino);
+        }
+        if !is_edge_connected_component(cells) {
+            return Err(Error::DisconnectedPolyomino);
+        }
+        Ok(Self(polyomino_cell_order_storage(cells)))
+    }
+
+    /// Builds a polyomino without validating non-emptiness or connectivity.
+    ///
+    /// Callers must guarantee `cells` is non-empty and edge-connected.
+    pub(crate) fn new_unchecked(cells: &[Cell]) -> Self {
         Self(polyomino_cell_order_storage(cells))
     }
 
     /// Returns a new polyomino with `cell` added.
     ///
     /// Idempotent: if `cell` is already present, returns an equivalent
-    /// polyomino. # Panics
-    /// Panics if adding `cell` would make the polyomino disconnected.
-    pub fn insert(&self, cell: Cell) -> Self {
+    /// polyomino.
+    ///
+    /// # Errors
+    /// Returns [`Error::DisconnectedPolyomino`] if adding `cell` would make the
+    /// polyomino disconnected.
+    pub fn insert(&self, cell: Cell) -> Result<Self, Error> {
         let mut cells = self.0.clone();
         cells.push(cell);
         Self::new(&cells)
@@ -38,10 +54,13 @@ impl Polyomino {
 
     /// Returns a new polyomino with `cell` removed.
     ///
-    /// Idempotent: if `cell` is not present, returns an equivalent polyomino
-    /// wrapped in `Some`. # Panics
-    /// Panics if adding `cell` would make the polyomino disconnected.
-    pub fn remove(&self, cell: Cell) -> Self {
+    /// Idempotent: if `cell` is not present, returns an equivalent polyomino.
+    ///
+    /// # Errors
+    /// Returns [`Error::EmptyPolyomino`] if removing `cell` would empty the
+    /// polyomino, or [`Error::DisconnectedPolyomino`] if it would leave the
+    /// remaining cells disconnected.
+    pub fn remove(&self, cell: Cell) -> Result<Self, Error> {
         let cells = self
             .0
             .iter()
@@ -94,6 +113,7 @@ pub fn is_edge_connected_component(cells: &[Cell]) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -154,7 +174,7 @@ mod tests {
 
     #[test]
     fn polyomino_cells_are_sorted() {
-        let r = Polyomino::new(&[Cell::new(1, 0), Cell::new(0, 0), Cell::new(0, 1)]);
+        let r = Polyomino::new(&[Cell::new(1, 0), Cell::new(0, 0), Cell::new(0, 1)]).unwrap();
         assert_eq!(
             r.cells(),
             vec![Cell::new(0, 0), Cell::new(0, 1), Cell::new(1, 0)]
@@ -163,43 +183,72 @@ mod tests {
 
     #[test]
     fn polyomino_len_matches_cell_count() {
-        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1), Cell::new(1, 1)]);
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1), Cell::new(1, 1)]).unwrap();
         assert_eq!(p.len(), 3);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn polyomino_panics_on_empty() {
-        let _ = Polyomino::new(&[]);
+    fn polyomino_new_empty_returns_err() {
+        assert!(matches!(Polyomino::new(&[]), Err(Error::EmptyPolyomino)));
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
-    fn polyomino_panics_on_disconnected() {
-        let _ = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 2)]);
+    fn polyomino_new_disconnected_returns_err() {
+        assert!(matches!(
+            Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 2)]),
+            Err(Error::DisconnectedPolyomino)
+        ));
+    }
+
+    #[test]
+    fn polyomino_new_distinguishes_empty_from_disconnected() {
+        // #45: empty and disconnected inputs must report distinct errors.
+        let empty = Polyomino::new(&[]);
+        let disconnected = Polyomino::new(&[Cell::new(0, 0), Cell::new(1, 1)]);
+        assert!(matches!(empty, Err(Error::EmptyPolyomino)));
+        assert!(matches!(disconnected, Err(Error::DisconnectedPolyomino)));
+    }
+
+    #[test]
+    fn polyomino_new_rejects_diagonal_only_inputs() {
+        // #46: replaces the deleted diagonal-polyomino tests — a diagonal-only
+        // set of cells is not edge-connected and must be rejected.
+        assert!(matches!(
+            Polyomino::new(&[Cell::new(0, 0), Cell::new(1, 1), Cell::new(2, 2)]),
+            Err(Error::DisconnectedPolyomino)
+        ));
     }
 
     // --- Polyomino::insert ---
 
     #[test]
     fn insert_adds_adjacent_cell() {
-        let p = Polyomino::new(&[Cell::new(0, 0)]);
-        let p2 = p.insert(Cell::new(0, 1));
+        let p = Polyomino::new(&[Cell::new(0, 0)]).unwrap();
+        let p2 = p.insert(Cell::new(0, 1)).unwrap();
         assert!(p2.cells().contains(&Cell::new(0, 1)));
         assert_eq!(p2.len(), 2);
     }
 
     #[test]
     fn insert_is_idempotent() {
-        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
-        let p2 = p.insert(Cell::new(0, 0));
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]).unwrap();
+        let p2 = p.insert(Cell::new(0, 0)).unwrap();
         assert_eq!(p2.len(), 2);
     }
 
     #[test]
+    fn insert_disconnected_returns_err() {
+        let p = Polyomino::new(&[Cell::new(0, 0)]).unwrap();
+        assert!(matches!(
+            p.insert(Cell::new(0, 2)),
+            Err(Error::DisconnectedPolyomino)
+        ));
+    }
+
+    #[test]
     fn insert_result_is_sorted() {
-        let p = Polyomino::new(&[Cell::new(0, 1)]);
-        let p2 = p.insert(Cell::new(0, 0));
+        let p = Polyomino::new(&[Cell::new(0, 1)]).unwrap();
+        let p2 = p.insert(Cell::new(0, 0)).unwrap();
         assert_eq!(p2.cells()[0], Cell::new(0, 0));
     }
 
@@ -207,16 +256,25 @@ mod tests {
 
     #[test]
     fn remove_deletes_cell() {
-        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
-        let p2 = p.remove(Cell::new(0, 1));
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]).unwrap();
+        let p2 = p.remove(Cell::new(0, 1)).unwrap();
         assert!(!p2.cells().contains(&Cell::new(0, 1)));
         assert_eq!(p2.len(), 1);
     }
 
     #[test]
     fn remove_is_idempotent() {
-        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
-        let p2 = p.remove(Cell::new(1, 1));
+        let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]).unwrap();
+        let p2 = p.remove(Cell::new(1, 1)).unwrap();
         assert_eq!(p2, p);
+    }
+
+    #[test]
+    fn remove_last_cell_returns_err() {
+        let p = Polyomino::new(&[Cell::new(0, 0)]).unwrap();
+        assert!(matches!(
+            p.remove(Cell::new(0, 0)),
+            Err(Error::EmptyPolyomino)
+        ));
     }
 }

--- a/src/constraints/cover.rs
+++ b/src/constraints/cover.rs
@@ -188,6 +188,13 @@ mod tests {
     }
 
     #[test]
+    fn polyomino_new_unchecked_builds_from_connected_cells() {
+        let p = Polyomino::new_unchecked(&[Cell::new(0, 0), Cell::new(0, 1)]);
+        assert_eq!(p.len(), 2);
+        assert_eq!(p.cells(), vec![Cell::new(0, 0), Cell::new(0, 1)]);
+    }
+
+    #[test]
     fn polyomino_new_empty_returns_err() {
         assert!(matches!(Polyomino::new(&[]), Err(Error::EmptyPolyomino)));
     }

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -28,6 +28,9 @@ impl Constraint {
     /// Returns `Error` if any cell in the constraint is outside the grid
     /// bounds.
     pub fn apply(&self, grid: Grid) -> Result<Grid, Error> {
+        // `g` is an immutable snapshot of the candidate sets at entry; every
+        // intersection below reads from it so each cell is narrowed against its
+        // original fill, not the partially-updated `grid` being folded.
         let g = grid.clone();
         self.0.iter().try_fold(grid, |grid, (cell, values)| {
             Ok(grid.set(cell, *values & g.get(cell)?))

--- a/src/constraints/tiling.rs
+++ b/src/constraints/tiling.rs
@@ -158,7 +158,10 @@ impl Tiling {
                 covered.insert(*c);
             }
             let cells: Vec<Cell> = cells.into_iter().collect();
-            tiling.polyominos.insert(Polyomino::new(&cells));
+            // `cells` is non-empty (the seed is always inserted) and
+            // edge-connected (grown only via `grid_neighbors`), so the
+            // validating `Polyomino::new` would always succeed here.
+            tiling.polyominos.insert(Polyomino::new_unchecked(&cells));
         }
 
         tiling
@@ -186,7 +189,7 @@ mod tests {
 
     fn poly(cells: &[(usize, usize)]) -> Polyomino {
         let cells: Vec<Cell> = cells.iter().map(|&(r, c)| Cell::new(r, c)).collect();
-        Polyomino::new(&cells)
+        Polyomino::new(&cells).unwrap()
     }
 
     #[test]

--- a/src/generator/generate.rs
+++ b/src/generator/generate.rs
@@ -26,31 +26,30 @@ pub const DEFAULT_SIZE_DISTRIBUTION: SizeDistribution =
 /// - 2 cells: [`Operation::Divide`] when divisible, otherwise [`Operation::Subtract`].
 /// - 3+ cells: [`Operation::Multiply`] when the product fits in `n²`, otherwise [`Operation::Add`].
 ///
-/// # Panics
-/// Panics if `values` is empty. A cage always covers at least one cell, so
-/// callers that obtain `values` from a cage's cells will never trigger this.
-#[must_use]
-#[allow(clippy::panic)]
-pub fn default_op_policy(values: &[N], n: Index) -> Operation {
+/// # Errors
+/// Returns [`Error::EmptyOpPolicyValues`] if `values` is empty. A cage always
+/// covers at least one cell, so callers that obtain `values` from a cage's
+/// cells will never trigger this.
+pub fn default_op_policy(values: &[N], n: Index) -> Result<Operation, Error> {
     use Operation::{Add, Divide, Given, Multiply, Subtract};
     match values.len() {
-        0 => panic!("default_op_policy called with empty values slice"),
-        1 => Given(M::from(values[0])),
+        0 => Err(Error::EmptyOpPolicyValues),
+        1 => Ok(Given(M::from(values[0]))),
         2 => {
             let (hi, lo) = (values[0].max(values[1]), values[0].min(values[1]));
             if hi.is_multiple_of(lo) {
-                Divide(M::from(hi / lo))
+                Ok(Divide(M::from(hi / lo)))
             } else {
-                Subtract(M::from(hi - lo))
+                Ok(Subtract(M::from(hi - lo)))
             }
         }
         _ => {
             let prod: M = values.iter().map(|&v| M::from(v)).product();
             let area = M::try_from(n * n).unwrap_or(M::MAX);
             if prod <= area {
-                Multiply(prod)
+                Ok(Multiply(prod))
             } else {
-                Add(values.iter().map(|&v| M::from(v)).sum())
+                Ok(Add(values.iter().map(|&v| M::from(v)).sum()))
             }
         }
     }
@@ -87,7 +86,7 @@ pub fn generate_with<R: Rng, F>(
     sizes: SizeDistribution,
 ) -> Result<Puzzle, Error>
 where
-    F: Fn(&[N], Index) -> Operation,
+    F: Fn(&[N], Index) -> Result<Operation, Error>,
 {
     let mut puzzle = Puzzle::new(n)?;
     let latin_square = generate_latin_square(n, rng);
@@ -100,7 +99,7 @@ where
             .iter()
             .map(|cell| latin_square[cell.row][cell.column])
             .collect();
-        let operation = op(&values, n);
+        let operation = op(&values, n)?;
         let cage = Cage::new(n_max, polyomino, operation);
         puzzle = puzzle.insert_cage(cage)?;
     }
@@ -108,39 +107,51 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn default_op_policy_one_cell_is_given() {
-        assert_eq!(default_op_policy(&[3], 4), Operation::Given(3));
+        assert_eq!(default_op_policy(&[3], 4).unwrap(), Operation::Given(3));
     }
 
     #[test]
     fn default_op_policy_two_cells_divisible_is_divide() {
-        assert_eq!(default_op_policy(&[2, 6], 6), Operation::Divide(3));
+        assert_eq!(default_op_policy(&[2, 6], 6).unwrap(), Operation::Divide(3));
     }
 
     #[test]
     fn default_op_policy_two_cells_not_divisible_is_subtract() {
-        assert_eq!(default_op_policy(&[2, 5], 6), Operation::Subtract(3));
+        assert_eq!(
+            default_op_policy(&[2, 5], 6).unwrap(),
+            Operation::Subtract(3)
+        );
     }
 
     #[test]
     fn default_op_policy_three_cells_product_within_n_squared_is_multiply() {
         // n²=16; product 1·2·3 = 6 ≤ 16
-        assert_eq!(default_op_policy(&[1, 2, 3], 4), Operation::Multiply(6));
+        assert_eq!(
+            default_op_policy(&[1, 2, 3], 4).unwrap(),
+            Operation::Multiply(6)
+        );
     }
 
     #[test]
     fn default_op_policy_three_cells_product_above_n_squared_is_add() {
         // n²=16; product 3·4·4 = 48 > 16
-        assert_eq!(default_op_policy(&[3, 4, 4], 4), Operation::Add(11));
+        assert_eq!(
+            default_op_policy(&[3, 4, 4], 4).unwrap(),
+            Operation::Add(11)
+        );
     }
 
     #[test]
-    #[should_panic(expected = "default_op_policy called with empty values slice")]
-    fn default_op_policy_empty_panics() {
-        let _ = default_op_policy(&[], 4);
+    fn default_op_policy_empty_returns_err() {
+        assert!(matches!(
+            default_op_policy(&[], 4),
+            Err(Error::EmptyOpPolicyValues)
+        ));
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -302,6 +302,12 @@ mod tests {
     }
 
     #[test]
+    fn row_last_index_succeeds() {
+        let g = Grid::new(3).unwrap();
+        assert!(g.row(2).is_ok());
+    }
+
+    #[test]
     fn column_returns_all_different_for_column() {
         use crate::constraints::cover::Cover;
         let g = Grid::new(3).unwrap();
@@ -316,6 +322,12 @@ mod tests {
     fn column_out_of_bounds_returns_err() {
         let g = Grid::new(3).unwrap();
         assert!(g.column(3).is_err());
+    }
+
+    #[test]
+    fn column_last_index_succeeds() {
+        let g = Grid::new(3).unwrap();
+        assert!(g.column(2).is_ok());
     }
 
     #[test]

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -49,18 +49,16 @@ impl Grid {
     }
 
     /// Creates an [`AllDifferent`] for the `index`th row of the grid.
-    /// # Panics
-    /// Panics if `index >= n`.
-    pub fn row(&self, index: usize) -> AllDifferent {
-        assert!(index <= self.n);
+    /// # Errors
+    /// Returns [`Error::IndexOutOfRange`] if `index` is not less than `n`.
+    pub fn row(&self, index: usize) -> Result<AllDifferent, Error> {
         AllDifferent::row(self.n, index)
     }
 
     /// Creates an [`AllDifferent`] for the `index`th column of the grid.
-    /// # Panics
-    /// Panics if `index >= n`.
-    pub fn column(&self, index: usize) -> AllDifferent {
-        assert!(index <= self.n);
+    /// # Errors
+    /// Returns [`Error::IndexOutOfRange`] if `index` is not less than `n`.
+    pub fn column(&self, index: usize) -> Result<AllDifferent, Error> {
         AllDifferent::column(self.n, index)
     }
 
@@ -290,7 +288,7 @@ mod tests {
     fn row_returns_all_different_for_row() {
         use crate::constraints::cover::Cover;
         let g = Grid::new(3).unwrap();
-        let r = g.row(1);
+        let r = g.row(1).unwrap();
         assert_eq!(
             r.cells(),
             vec![Cell::new(1, 0), Cell::new(1, 1), Cell::new(1, 2)]
@@ -298,14 +296,26 @@ mod tests {
     }
 
     #[test]
+    fn row_out_of_bounds_returns_err() {
+        let g = Grid::new(3).unwrap();
+        assert!(g.row(3).is_err());
+    }
+
+    #[test]
     fn column_returns_all_different_for_column() {
         use crate::constraints::cover::Cover;
         let g = Grid::new(3).unwrap();
-        let c = g.column(2);
+        let c = g.column(2).unwrap();
         assert_eq!(
             c.cells(),
             vec![Cell::new(0, 2), Cell::new(1, 2), Cell::new(2, 2)]
         );
+    }
+
+    #[test]
+    fn column_out_of_bounds_returns_err() {
+        let g = Grid::new(3).unwrap();
+        assert!(g.column(3).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub use constraints::{
         operation::{Operation, Operator},
         operator_tuples,
     },
+    cover::{Cover, Polyomino},
     tiling::SizeDistribution,
 };
 pub use generator::generate::{

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -81,10 +81,12 @@ impl Puzzle {
         Ok(Self {
             grid: Grid::new(n)?,
             constraints: Arc::new(PuzzleConstraints {
-                row: (0..n).map(|row| AllDifferent::row(n, row)).collect(),
+                row: (0..n)
+                    .map(|row| AllDifferent::row(n, row))
+                    .collect::<Result<Vec<_>, _>>()?,
                 column: (0..n)
                     .map(|column| AllDifferent::column(n, column))
-                    .collect(),
+                    .collect::<Result<Vec<_>, _>>()?,
                 cage: Cages::empty(n),
             }),
         })
@@ -235,22 +237,24 @@ impl Puzzle {
     }
 
     /// Apply `delta` by intersecting per-cell with the current grid, then
-    /// propagate to the fixed point. Always returns a `Puzzle`; the caller
-    /// inspects [`Self::is_valid`].
+    /// propagate to the fixed point. On success the caller inspects
+    /// [`Self::is_valid`] to learn whether propagation produced a contradiction.
     ///
-    /// # Panics
-    /// Panics if `delta.n()` does not match `self.n()`.
-    pub fn narrow(&self, delta: &Delta) -> Self {
+    /// # Errors
+    /// Returns [`Error::DeltaSizeMismatch`] if `delta.n()` does not match
+    /// `self.n()`.
+    pub fn narrow(&self, delta: &Delta) -> Result<Self, Error> {
         self.apply_delta(delta, |a, b| a & b)
     }
 
     /// Apply `delta` by unioning per-cell with the current grid, then propagate
-    /// to the fixed point. Always returns a `Puzzle`; the caller inspects
-    /// [`Self::is_valid`].
+    /// to the fixed point. On success the caller inspects [`Self::is_valid`] to
+    /// learn whether propagation produced a contradiction.
     ///
-    /// # Panics
-    /// Panics if `delta.n()` does not match `self.n()`.
-    pub fn widen(&self, delta: &Delta) -> Self {
+    /// # Errors
+    /// Returns [`Error::DeltaSizeMismatch`] if `delta.n()` does not match
+    /// `self.n()`.
+    pub fn widen(&self, delta: &Delta) -> Result<Self, Error> {
         self.apply_delta(delta, |a, b| a | b)
     }
 
@@ -303,7 +307,7 @@ impl Puzzle {
             for (cell, &value) in cells.iter().zip(tuple.iter()) {
                 delta = delta.set(*cell, Fill::new([value]));
             }
-            let after = self.narrow(&delta);
+            let after = self.narrow(&delta)?;
             if !after.is_valid() {
                 continue;
             }
@@ -337,23 +341,23 @@ impl Puzzle {
         Ok(results)
     }
 
-    fn apply_delta(&self, delta: &Delta, op: impl Fn(Fill, Fill) -> Fill) -> Self {
-        assert_eq!(
-            delta.n(),
-            self.n(),
-            "delta size {} must match puzzle size {}",
-            delta.n(),
-            self.n(),
-        );
+    fn apply_delta(
+        &self,
+        delta: &Delta,
+        op: impl Fn(Fill, Fill) -> Fill,
+    ) -> Result<Self, Error> {
+        if delta.n() != self.n() {
+            return Err(Error::DeltaSizeMismatch(delta.n(), self.n()));
+        }
         let mut grid = self.grid.clone();
         for ((cell, current), (_, delta_v)) in self.grid.entries().zip(delta.grid().entries()) {
             grid = grid.set(&cell, op(current, delta_v));
         }
-        Self {
+        Ok(Self {
             grid,
             constraints: self.constraints.clone(),
         }
-        .propagate_fully()
+        .propagate_fully())
     }
 }
 
@@ -413,7 +417,11 @@ mod tests {
             .iter()
             .map(|&(row, column)| Cell::new(row, column))
             .collect();
-        Cage::new(n, Polyomino::new(&cells), Operation::Add(u16::from(n)))
+        Cage::new(
+            n,
+            Polyomino::new(&cells).unwrap(),
+            Operation::Add(u16::from(n)),
+        )
     }
 
     fn poly(cells: &[(usize, usize)]) -> Polyomino {
@@ -423,6 +431,7 @@ mod tests {
                 .map(|&(row, column)| Cell::new(row, column))
                 .collect::<Vec<_>>(),
         )
+        .unwrap()
     }
 
     #[test]
@@ -587,14 +596,18 @@ mod tests {
         let cell = Cell::new(row, column);
         Cage::new(
             value,
-            Polyomino::new(&[cell]),
+            Polyomino::new(&[cell]).unwrap(),
             Operation::Given(u16::from(value)),
         )
     }
 
     fn row_add(n: u8, row: usize, target: u8) -> Cage {
         let cells: Vec<Cell> = (0..n as usize).map(|col| Cell::new(row, col)).collect();
-        Cage::new(n, Polyomino::new(&cells), Operation::Add(u16::from(target)))
+        Cage::new(
+            n,
+            Polyomino::new(&cells).unwrap(),
+            Operation::Add(u16::from(target)),
+        )
     }
 
     #[test]
@@ -820,7 +833,11 @@ mod tests {
             .iter()
             .map(|&(row, column)| Cell::new(row, column))
             .collect();
-        Cage::new(n, Polyomino::new(&cells), Operation::Add(u16::from(target)))
+        Cage::new(
+            n,
+            Polyomino::new(&cells).unwrap(),
+            Operation::Add(u16::from(target)),
+        )
     }
 
     #[test]
@@ -896,7 +913,7 @@ mod tests {
     fn narrow_with_identity_delta_is_no_op() {
         let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
         let baseline = p.clone().propagate_fully();
-        let narrowed = p.narrow(&Delta::identity(2).unwrap());
+        let narrowed = p.narrow(&Delta::identity(2).unwrap()).unwrap();
         assert_eq!(narrowed.grid, baseline.grid);
     }
 
@@ -908,7 +925,7 @@ mod tests {
         let delta = Delta::identity(2)
             .unwrap()
             .set(Cell::new(0, 0), Fill::new([1]));
-        let narrowed = p.narrow(&delta);
+        let narrowed = p.narrow(&delta).unwrap();
         assert!(narrowed.is_valid());
         assert_eq!(narrowed.grid.get(&Cell::new(0, 0)).unwrap(), Fill::new([1]));
         assert_eq!(narrowed.grid.get(&Cell::new(0, 1)).unwrap(), Fill::new([2]));
@@ -922,7 +939,7 @@ mod tests {
         let delta = Delta::identity(2)
             .unwrap()
             .set(Cell::new(0, 0), Fill::default());
-        let narrowed = p.narrow(&delta);
+        let narrowed = p.narrow(&delta).unwrap();
         assert!(!narrowed.is_valid());
     }
 
@@ -930,7 +947,7 @@ mod tests {
     fn widen_with_identity_delta_is_no_op() {
         let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
         let baseline = p.clone().propagate_fully();
-        let widened = p.widen(&Delta::identity(2).unwrap());
+        let widened = p.widen(&Delta::identity(2).unwrap()).unwrap();
         assert_eq!(widened.grid, baseline.grid);
     }
 
@@ -941,7 +958,7 @@ mod tests {
         // to the same fixed point.
         let p = Puzzle::new(2).unwrap().insert_cage(given(0, 0, 1)).unwrap();
         let baseline = p.propagate_fully();
-        let widened = baseline.widen(&Delta::identity(2).unwrap());
+        let widened = baseline.widen(&Delta::identity(2).unwrap()).unwrap();
         assert!(widened.is_valid());
         for cell in widened.grid.cells() {
             assert!(widened.grid.get(&cell).unwrap().is_singleton());
@@ -949,17 +966,21 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "delta size")]
-    fn narrow_panics_on_size_mismatch() {
+    fn narrow_size_mismatch_returns_err() {
         let p = Puzzle::new(2).unwrap();
-        let _ = p.narrow(&Delta::identity(3).unwrap());
+        assert!(matches!(
+            p.narrow(&Delta::identity(3).unwrap()),
+            Err(Error::DeltaSizeMismatch(3, 2))
+        ));
     }
 
     #[test]
-    #[should_panic(expected = "delta size")]
-    fn widen_panics_on_size_mismatch() {
+    fn widen_size_mismatch_returns_err() {
         let p = Puzzle::new(2).unwrap();
-        let _ = p.widen(&Delta::identity(3).unwrap());
+        assert!(matches!(
+            p.widen(&Delta::identity(3).unwrap()),
+            Err(Error::DeltaSizeMismatch(3, 2))
+        ));
     }
 
     fn sub_cage(cells: &[(usize, usize)], n: u8, target: u8) -> Cage {
@@ -969,7 +990,7 @@ mod tests {
             .collect();
         Cage::new(
             n,
-            Polyomino::new(&cells),
+            Polyomino::new(&cells).unwrap(),
             Operation::Subtract(u16::from(target)),
         )
     }

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -489,6 +489,7 @@ mod tests {
             .unwrap();
         let result = puzzle.insert_cage(make_cage(&[(0, 1), (0, 2)], 4));
         assert!(matches!(result, Err(Error::CageConflict(_, _))));
+        assert!(result.err().unwrap().to_string().contains("conflicts with"));
     }
 
     #[test]
@@ -995,10 +996,16 @@ mod tests {
     fn rank_returns_err_for_unknown_cage() {
         let p = Puzzle::new(4).unwrap();
         let cage = make_cage(&[(0, 0), (0, 1)], 4);
-        assert!(matches!(
-            p.rank_tuples_for_cage(&cage),
-            Err(Error::CageNotInPuzzle(_)),
-        ));
+        let result = p.rank_tuples_for_cage(&cage);
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("not in this puzzle")
+        );
+        assert!(matches!(result, Err(Error::CageNotInPuzzle(_))));
     }
 
     #[test]

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -341,11 +341,7 @@ impl Puzzle {
         Ok(results)
     }
 
-    fn apply_delta(
-        &self,
-        delta: &Delta,
-        op: impl Fn(Fill, Fill) -> Fill,
-    ) -> Result<Self, Error> {
+    fn apply_delta(&self, delta: &Delta, op: impl Fn(Fill, Fill) -> Fill) -> Result<Self, Error> {
         if delta.n() != self.n() {
             return Err(Error::DeltaSizeMismatch(delta.n(), self.n()));
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -348,4 +348,55 @@ mod tests {
         assert!(n.contains(&Cell::new(1, 0)));
         assert!(n.contains(&Cell::new(0, 1)));
     }
+
+    #[test]
+    fn error_display_covers_all_variants() {
+        use crate::Error;
+        let c = Cell::new(1, 2);
+        assert_eq!(Error::InvalidGridSize(0).to_string(), "invalid grid size 0");
+        assert_eq!(
+            Error::InvalidCell(c).to_string(),
+            "cell (1, 2) is outside the grid"
+        );
+        assert_eq!(
+            Error::CellNotCovered(c).to_string(),
+            "cell (1, 2) is not covered by any polyomino"
+        );
+        assert_eq!(
+            Error::WouldDisconnect(c).to_string(),
+            "removing cell (1, 2) would disconnect the polyomino"
+        );
+        assert_eq!(
+            Error::TargetNotAdjacent.to_string(),
+            "target cell is not edge-adjacent to the polyomino"
+        );
+        assert_eq!(
+            Error::CellAlreadyInPolyomino(c).to_string(),
+            "cell (1, 2) is already in the polyomino"
+        );
+        assert_eq!(
+            Error::RemovalWouldEmptyPolyomino(c).to_string(),
+            "removing cell (1, 2) would leave an empty polyomino"
+        );
+        assert_eq!(
+            Error::EmptyPolyomino.to_string(),
+            "polyomino cannot be constructed from an empty cell slice"
+        );
+        assert_eq!(
+            Error::DisconnectedPolyomino.to_string(),
+            "polyomino cells are not edge-connected"
+        );
+        assert_eq!(
+            Error::IndexOutOfRange(3, 2).to_string(),
+            "index 3 is out of range for grid of size 2"
+        );
+        assert_eq!(
+            Error::DeltaSizeMismatch(4, 3).to_string(),
+            "delta size 4 does not match puzzle size 3"
+        );
+        assert_eq!(
+            Error::EmptyOpPolicyValues.to_string(),
+            "operation policy received an empty value slice"
+        );
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,7 @@
-use std::ops::{BitAnd, BitOr};
+use std::{
+    fmt,
+    ops::{BitAnd, BitOr},
+};
 
 use crate::Cage;
 
@@ -159,6 +162,61 @@ pub enum Error {
     /// An operation policy received an empty value slice.
     EmptyOpPolicyValues,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidGridSize(n) => write!(f, "invalid grid size {n}"),
+            Self::InvalidCell(c) => {
+                write!(f, "cell ({}, {}) is outside the grid", c.row, c.column)
+            }
+            Self::CageConflict(new, existing) => {
+                write!(f, "cage {new:?} conflicts with existing cage {existing:?}")
+            }
+            Self::CageNotInPuzzle(cage) => write!(f, "cage {cage:?} is not in this puzzle"),
+            Self::CellNotCovered(c) => write!(
+                f,
+                "cell ({}, {}) is not covered by any polyomino",
+                c.row, c.column
+            ),
+            Self::WouldDisconnect(c) => write!(
+                f,
+                "removing cell ({}, {}) would disconnect the polyomino",
+                c.row, c.column
+            ),
+            Self::TargetNotAdjacent => {
+                write!(f, "target cell is not edge-adjacent to the polyomino")
+            }
+            Self::CellAlreadyInPolyomino(c) => write!(
+                f,
+                "cell ({}, {}) is already in the polyomino",
+                c.row, c.column
+            ),
+            Self::RemovalWouldEmptyPolyomino(c) => write!(
+                f,
+                "removing cell ({}, {}) would leave an empty polyomino",
+                c.row, c.column
+            ),
+            Self::EmptyPolyomino => write!(
+                f,
+                "polyomino cannot be constructed from an empty cell slice"
+            ),
+            Self::DisconnectedPolyomino => write!(f, "polyomino cells are not edge-connected"),
+            Self::IndexOutOfRange(index, n) => {
+                write!(f, "index {index} is out of range for grid of size {n}")
+            }
+            Self::DeltaSizeMismatch(delta_n, puzzle_n) => write!(
+                f,
+                "delta size {delta_n} does not match puzzle size {puzzle_n}"
+            ),
+            Self::EmptyOpPolicyValues => {
+                write!(f, "operation policy received an empty value slice")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 #[cfg(test)]
 mod tests {

--- a/src/types.rs
+++ b/src/types.rs
@@ -134,16 +134,30 @@ pub enum Error {
     /// A tiling operation referenced a cell that no polyomino covers.
     CellNotCovered(Cell),
     /// Removing a cell from a polyomino would leave the remaining cells
-    /// disconnected. Raised by `Polyomino::without`.
+    /// disconnected. Raised by `Polyomino::remove`.
     WouldDisconnect(Cell),
     /// A target cell is not edge-connected to any cell of the polyomino it was
     /// applied to.
     TargetNotAdjacent,
-    /// A cell passed to `Polyomino::extend` is already in the polyomino.
+    /// A cell passed to `Polyomino::insert` is already in the polyomino.
     CellAlreadyInPolyomino(Cell),
-    /// A `Polyomino::without` call would remove the polyomino's only remaining
+    /// A `Polyomino::remove` call would remove the polyomino's only remaining
     /// cell.
     RemovalWouldEmptyPolyomino(Cell),
+    /// A `Polyomino` was constructed from an empty cell slice.
+    EmptyPolyomino,
+    /// A `Polyomino` was constructed from cells that are not edge-connected
+    /// (e.g. a diagonal-only pair).
+    DisconnectedPolyomino,
+    /// A row/column index passed to `AllDifferent::row`/`column` or
+    /// `Grid::row`/`column` is not less than the grid size. Carries
+    /// `(index, n)`.
+    IndexOutOfRange(Index, Index),
+    /// A `Delta` passed to `Puzzle::narrow`/`widen` has a grid size that does
+    /// not match the puzzle's. Carries `(delta_n, puzzle_n)`.
+    DeltaSizeMismatch(Index, Index),
+    /// An operation policy received an empty value slice.
+    EmptyOpPolicyValues,
 }
 
 #[cfg(test)]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -106,7 +106,7 @@ fn uniqueness_and_solutions_buckets_agree() {
 fn custom_op_policy_overrides_default() {
     let policy = |values: &[u8], n: usize| {
         if values.len() == 2 {
-            Operation::Add(values.iter().map(|&v| u16::from(v)).sum())
+            Ok(Operation::Add(values.iter().map(|&v| u16::from(v)).sum()))
         } else {
             default_op_policy(values, n)
         }
@@ -161,7 +161,7 @@ fn given_cage(row: usize, column: usize, value: u8) -> Cage {
     let cell = Cell::new(row, column);
     Cage::new(
         value,
-        Polyomino::new(&[cell]),
+        Polyomino::new(&[cell]).unwrap(),
         Operation::Given(u16::from(value)),
     )
 }
@@ -236,10 +236,10 @@ fn singleton_grid_yields_its_only_cell() {
 
 #[test]
 fn polyomino_extend_and_without_are_public() {
-    let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]);
-    let extended = p.insert(Cell::new(0, 2));
+    let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]).unwrap();
+    let extended = p.insert(Cell::new(0, 2)).unwrap();
     assert_eq!(extended.len(), 3);
-    let shrunk = extended.remove(Cell::new(0, 2));
+    let shrunk = extended.remove(Cell::new(0, 2)).unwrap();
     assert_eq!(shrunk, p);
 }
 
@@ -262,7 +262,7 @@ fn puzzle_cage_accessors_are_reachable() {
 fn rank_tuples_for_cage_is_public_and_returns_scored_entries() {
     // Tuples (1,2) and (2,1) tie on reduction; lex tiebreak orders (1,2) first.
     let cells = [Cell::new(0, 0), Cell::new(0, 1)];
-    let cage = Cage::new(4, Polyomino::new(&cells), Operation::Add(3));
+    let cage = Cage::new(4, Polyomino::new(&cells).unwrap(), Operation::Add(3));
     let p = Puzzle::new(4).unwrap().insert_cage(cage.clone()).unwrap();
     let ranked: Vec<(Vec<u8>, Puzzle, NarrowingScore)> = p.rank_tuples_for_cage(&cage).unwrap();
     let tuples: Vec<Vec<u8>> = ranked.iter().map(|(t, ..)| t.clone()).collect();
@@ -337,7 +337,7 @@ fn delta_narrow_widen_and_propagate_fully_are_public() {
     // Identity delta is a no-op after propagation, regardless of starting state.
     let p = Puzzle::new(2).unwrap();
     let identity = Delta::identity(2).unwrap();
-    let unchanged = p.narrow(&identity);
+    let unchanged = p.narrow(&identity).unwrap();
     assert!(unchanged.is_valid());
 
     // Pinning (0,0)={1} on a 2×2 grid forces a unique completion via narrow +
@@ -345,7 +345,7 @@ fn delta_narrow_widen_and_propagate_fully_are_public() {
     let pinning = Delta::identity(2)
         .unwrap()
         .set(Cell::new(0, 0), Fill::new([1]));
-    let pinned = Puzzle::new(2).unwrap().narrow(&pinning);
+    let pinned = Puzzle::new(2).unwrap().narrow(&pinning).unwrap();
     assert!(pinned.is_valid());
     assert_eq!(pinned.candidates(Cell::new(1, 1)).unwrap(), Fill::new([1]),);
 
@@ -353,7 +353,7 @@ fn delta_narrow_widen_and_propagate_fully_are_public() {
     let emptying = Delta::identity(2)
         .unwrap()
         .set(Cell::new(0, 0), Fill::new([]));
-    let invalid = Puzzle::new(2).unwrap().narrow(&emptying);
+    let invalid = Puzzle::new(2).unwrap().narrow(&emptying).unwrap();
     assert!(!invalid.is_valid());
 
     // Widen with the identity over a fully propagated puzzle re-narrows back to the
@@ -363,7 +363,7 @@ fn delta_narrow_widen_and_propagate_fully_are_public() {
         .insert_cage(given_cage(0, 0, 1))
         .unwrap()
         .propagate_fully();
-    let rewidened = solved.widen(&identity);
+    let rewidened = solved.widen(&identity).unwrap();
     assert!(rewidened.is_valid());
     assert_eq!(
         rewidened.candidates(Cell::new(1, 1)).unwrap(),
@@ -380,13 +380,13 @@ fn solve_simple_2x2_puzzle() {
         .unwrap()
         .insert_cage(Cage::new(
             2,
-            Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]),
+            Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]).unwrap(),
             Operation::Add(3),
         ))
         .unwrap()
         .insert_cage(Cage::new(
             2,
-            Polyomino::new(&[Cell::new(1, 0), Cell::new(1, 1)]),
+            Polyomino::new(&[Cell::new(1, 0), Cell::new(1, 1)]).unwrap(),
             Operation::Add(3),
         ))
         .unwrap();

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -4,10 +4,9 @@
 #![allow(clippy::unwrap_used)]
 
 use kenken::{
-    Cage, Cell, DEFAULT_SIZE_DISTRIBUTION, Delta, Fill, Grid, NarrowingScore, Operation, Operator,
-    Puzzle, SizeDistribution, Solver, Uniqueness,
-    constraints::cover::{Cover, Polyomino},
-    default_op_policy, generate, generate_with,
+    Cage, Cell, Cover, DEFAULT_SIZE_DISTRIBUTION, Delta, Fill, Grid, NarrowingScore, Operation,
+    Operator, Polyomino, Puzzle, SizeDistribution, Solver, Uniqueness, default_op_policy, generate,
+    generate_with,
 };
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -214,7 +213,6 @@ fn puzzle_cells_visits_every_grid_cell() {
 
 #[test]
 fn puzzle_cover_len_equals_n_squared() {
-    use kenken::constraints::cover::Cover;
     let p = Puzzle::new(3).unwrap();
     assert_eq!(Cover::len(&p), 9);
     assert_eq!(Cover::cells(&p).len(), 9);

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -235,7 +235,7 @@ fn singleton_grid_yields_its_only_cell() {
 }
 
 #[test]
-fn polyomino_extend_and_without_are_public() {
+fn polyomino_insert_and_remove_are_public() {
     let p = Polyomino::new(&[Cell::new(0, 0), Cell::new(0, 1)]).unwrap();
     let extended = p.insert(Cell::new(0, 2)).unwrap();
     assert_eq!(extended.len(), 3);
@@ -296,7 +296,9 @@ fn cage_valid_operators_branches_by_cell_count() {
 #[test]
 fn cage_valid_targets_yields_legal_targets_in_ascending_order() {
     let cells = [Cell::new(0, 0), Cell::new(0, 1)];
-    let subtract: Vec<Operation> = Cage::valid_targets(&cells, Operator::Subtract, 4).collect();
+    let subtract: Vec<Operation> = Cage::valid_targets(&cells, Operator::Subtract, 4)
+        .unwrap()
+        .collect();
     assert_eq!(
         subtract,
         vec![
@@ -305,7 +307,9 @@ fn cage_valid_targets_yields_legal_targets_in_ascending_order() {
             Operation::Subtract(3),
         ]
     );
-    let divide: Vec<Operation> = Cage::valid_targets(&cells, Operator::Divide, 4).collect();
+    let divide: Vec<Operation> = Cage::valid_targets(&cells, Operator::Divide, 4)
+        .unwrap()
+        .collect();
     assert_eq!(
         divide,
         vec![
@@ -319,17 +323,17 @@ fn cage_valid_targets_yields_legal_targets_in_ascending_order() {
 #[test]
 fn cage_is_valid_filters_operator_target_pairs() {
     let singleton = [Cell::new(0, 0)];
-    assert!(Cage::is_valid(&singleton, Operation::Given(3), 4));
-    assert!(!Cage::is_valid(&singleton, Operation::Add(3), 4));
+    assert!(Cage::is_valid(&singleton, Operation::Given(3), 4).unwrap());
+    assert!(!Cage::is_valid(&singleton, Operation::Add(3), 4).unwrap());
 
     let pair = [Cell::new(0, 0), Cell::new(0, 1)];
-    assert!(Cage::is_valid(&pair, Operation::Subtract(2), 4));
-    assert!(!Cage::is_valid(&pair, Operation::Subtract(0), 4));
-    assert!(!Cage::is_valid(&pair, Operation::Divide(1), 4));
+    assert!(Cage::is_valid(&pair, Operation::Subtract(2), 4).unwrap());
+    assert!(!Cage::is_valid(&pair, Operation::Subtract(0), 4).unwrap());
+    assert!(!Cage::is_valid(&pair, Operation::Divide(1), 4).unwrap());
 
     let triple = [Cell::new(0, 0), Cell::new(0, 1), Cell::new(0, 2)];
-    assert!(Cage::is_valid(&triple, Operation::Add(6), 4));
-    assert!(!Cage::is_valid(&triple, Operation::Subtract(1), 4));
+    assert!(Cage::is_valid(&triple, Operation::Add(6), 4).unwrap());
+    assert!(!Cage::is_valid(&triple, Operation::Subtract(1), 4).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Overhauls the public API to replace panicking functions with proper `Result` returns, consistent with the rest of the construction API.

- Re-export `Cover` and `Polyomino` from the crate root so importers no longer need the full `constraints::cover::` path
- Convert `Polyomino::new`, `insert`, and `remove` to return `Result` with new `EmptyPolyomino` and `DisconnectedPolyomino` error variants that distinguish the two failure modes
- Convert `AllDifferent::row` and `AllDifferent::column` to return `Result<_, Error::IndexOutOfRange>` with a correct `index < n` bounds check (also fixes a `<= n` off-by-one in `Grid`)
- Convert `Puzzle::narrow` and `Puzzle::widen` to return `Result` with a new `DeltaSizeMismatch` error variant
- Convert `default_op_policy` to return `Result` with a new `EmptyOpPolicyValues` variant; update `generate_with`'s callback bound accordingly
- Surface `Polyomino::new` errors from `Cage::valid_targets` and `Cage::is_valid` instead of swallowing them
- Add `Polyomino::new_unchecked` for the internal tiling path where validity is guaranteed by construction
- Fill test gaps for all new error paths

## Test plan

- `cargo test` — all 245 unit tests and 29 integration tests pass
- `cargo clippy` — no warnings