### PR TITLE
refactor: derive PartialEq and Eq on core puzzle types

### DIFF
--- a/src/constraints/all_different.rs
+++ b/src/constraints/all_different.rs
@@ -7,7 +7,7 @@ use crate::{
 /// A constraint that ensures each cell in a row or column has a different
 /// value.
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AllDifferent(Vec<Cell>);
 
 impl AllDifferent {

--- a/src/constraints/cage/builder.rs
+++ b/src/constraints/cage/builder.rs
@@ -23,7 +23,7 @@ pub type Tuple = Vec<N>;
 /// assignments that repeat a value within any shared row or column of the
 /// polyomino.
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cage {
     polyomino: Polyomino,
     operation: Operation,

--- a/src/constraints/tiling.rs
+++ b/src/constraints/tiling.rs
@@ -37,7 +37,7 @@ impl SizeDistribution {
 /// - Every polyomino's cells are edge-connected.
 /// - Every cell of every polyomino lies inside the `n`×`n` grid.
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Tiling {
     n: usize,
     polyominos: HashSet<Polyomino>,

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -68,7 +68,7 @@ pub struct NarrowingScore {
 ///   behind an [`Arc`]. Cloning bumps a reference count rather than duplicating data. Mutating
 ///   methods use [`Arc::make_mut`] to copy-on-write only when necessary.
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Puzzle {
     grid: Grid,
     constraints: Arc<PuzzleConstraints>,
@@ -1119,7 +1119,7 @@ mod tests {
 ///
 /// Stored behind an [`Arc`] so that cloning a [`Puzzle`] during search shares
 /// this allocation instead of duplicating it.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PuzzleConstraints {
     pub row: Vec<AllDifferent>,
     pub column: Vec<AllDifferent>,
@@ -1158,7 +1158,7 @@ impl PuzzleConstraints {
 /// the new cage's cells against the tiling, which is acceptable because cages
 /// are only added at construction time.
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cages {
     tiling: Tiling,
     data: HashMap<Polyomino, Cage>,


### PR DESCRIPTION
## Summary

- Derives `PartialEq` and `Eq` on `AllDifferent`, `Tiling`, `Cage`, `Puzzle`, `PuzzleConstraints`, and `Cages`.
- Stacks on #51 (derive `Debug`).

## Test plan

- [ ] Pre-commit checks pass (fmt, clippy, doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)