### PR TITLE
Remove Grid.entries() method and associated tests

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -91,13 +91,6 @@ impl Grid {
         self.fills.iter().any(|values| values.is_empty())
     }
 
-    // TODO Get rid of Grid.entries().
-    /// Returns an iterator over every `(cell, fill)` pair in row-major order.
-    pub fn entries(&self) -> impl Iterator<Item = (Cell, Fill)> + '_ {
-        self.cells()
-            .map(|cell| (cell, self.fills[cell.row * self.n + cell.column]))
-    }
-
     const fn fill_index(&self, cell: &Cell) -> Option<usize> {
         if cell.row < self.n && cell.column < self.n {
             Some(cell.row * self.n + cell.column)
@@ -250,43 +243,4 @@ mod tests {
         assert_eq!(after, before);
     }
 
-    #[test]
-    fn entries_count_equals_n_squared() {
-        let g = Grid::new(3).unwrap();
-        assert_eq!(g.entries().count(), 9);
-    }
-
-    #[test]
-    fn entries_are_in_row_major_order() {
-        let g = Grid::new(2).unwrap();
-        let cells: Vec<Cell> = g.entries().map(|(c, _)| c).collect();
-        assert_eq!(
-            cells,
-            vec![
-                Cell::new(0, 0),
-                Cell::new(0, 1),
-                Cell::new(1, 0),
-                Cell::new(1, 1),
-            ]
-        );
-    }
-
-    #[test]
-    fn entries_reflect_set_values() {
-        let cell = Cell::new(1, 2);
-        let g = Grid::new(3).unwrap().set(&cell, Fill::new([2]));
-        let fill = g.entries().find(|(c, _)| c == &cell).map(|(_, f)| f);
-        assert_eq!(fill, Some(Fill::new([2])));
-    }
-
-    #[test]
-    fn entries_covers_all_cells() {
-        let n = 4;
-        let g = Grid::new(n).unwrap();
-        let mut seen: std::collections::HashSet<Cell> = std::collections::HashSet::new();
-        for (cell, _) in g.entries() {
-            assert!(seen.insert(cell), "duplicate cell {cell:?}");
-        }
-        assert_eq!(seen.len(), n * n);
-    }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -242,5 +242,4 @@ mod tests {
         let after = g.set(&Cell::new(9, 9), Fill::new([1]));
         assert_eq!(after, before);
     }
-
 }


### PR DESCRIPTION
## Summary
Removed the `Grid.entries()` method along with its four associated unit tests. This method was marked with a TODO comment indicating it should be removed, and it appears to have been replaced by or superseded by other iteration mechanisms in the codebase.

## Changes
- **Removed method**: `Grid.entries()` - a public method that returned an iterator over `(Cell, Fill)` pairs in row-major order
- **Removed tests**: Four unit tests that validated the `entries()` method:
  - `entries_count_equals_n_squared()` - verified iterator count
  - `entries_are_in_row_major_order()` - verified ordering
  - `entries_reflect_set_values()` - verified values were current
  - `entries_covers_all_cells()` - verified complete coverage

## Implementation Details
The removed `entries()` method was a convenience wrapper that combined `cells()` iteration with direct access to the `fills` array. The TODO comment in the original code suggests this method was identified as technical debt and has now been cleaned up.

https://claude.ai/code/session_01PsPVhZDjyPKF7UpRYpNQQM