### PR TITLE
Enable clippy must_use_candidate lint as warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ strum = { version = "0.28", features = ["derive"] }
 
 [dev-dependencies]
 rand_chacha = "0.10.0"
+
+[lints.clippy]
+must_use_candidate = "warn"


### PR DESCRIPTION
This change enables the `must_use_candidate` clippy lint at the warning level for the project.

## Summary
Added clippy lint configuration to encourage marking functions that return values with the `#[must_use]` attribute when appropriate.

## Changes
- Added `[lints.clippy]` section to `Cargo.toml`
- Set `must_use_candidate` lint to "warn" level

## Details
This lint helps identify functions that return meaningful values but don't have the `#[must_use]` attribute, which can help prevent bugs where return values are accidentally ignored. By enabling this as a warning, developers will be prompted to add `#[must_use]` attributes to functions where ignoring the return value would likely indicate a programming error.

https://claude.ai/code/session_011R5aUpsvDrfY4hCf8Eybe1