### PR TITLE
Replace panic with Result in sequence_operation for empty tuples

### DIFF
--- a/src/constraints/cage/arithmetic.rs
+++ b/src/constraints/cage/arithmetic.rs
@@ -1,6 +1,6 @@
 use crate::{
     constraints::cage::Tuple,
-    types::{M, N},
+    types::{Error, M, N},
 };
 
 /// Returns an iterator over all non-decreasing `k`-tuples with values in
@@ -60,14 +60,15 @@ fn simplex_multisets(
                     t
                 })
                 .filter(move |t| {
-                    let v = sequence_operation(f, t);
-                    if t.len() == tuple_size {
-                        v == s
-                    } else {
-                        // Prune partials whose accumulated value already exceeds s; extending
-                        // them can only increase it.
-                        v <= s
-                    }
+                    sequence_operation(f, t).is_ok_and(|v| {
+                        if t.len() == tuple_size {
+                            v == s
+                        } else {
+                            // Prune partials whose accumulated value already exceeds s; extending
+                            // them can only increase it.
+                            v <= s
+                        }
+                    })
                 })
                 .collect::<Vec<_>>()
         }))
@@ -76,13 +77,12 @@ fn simplex_multisets(
 }
 
 /// Reduces `t` by left-folding `f` over its elements, starting from the first
-/// element widened to `M`. Panics if `t` is empty.
-#[allow(clippy::panic)]
-fn sequence_operation(f: impl Fn(M, N) -> M, t: &[N]) -> M {
+/// element widened to `M`. Returns [`Error::EmptyTuple`] if `t` is empty.
+fn sequence_operation(f: impl Fn(M, N) -> M, t: &[N]) -> Result<M, Error> {
     let Some((&t_0, rest)) = t.split_first() else {
-        panic!("tuple must have at least one element");
+        return Err(Error::EmptyTuple);
     };
-    rest.iter().fold(M::from(t_0), |acc, &i| f(acc, i))
+    Ok(rest.iter().fold(M::from(t_0), |acc, &i| f(acc, i)))
 }
 
 #[cfg(test)]
@@ -215,12 +215,14 @@ mod tests {
 
     #[test]
     fn sequence_operation_with_named_function_folds_correctly() {
-        assert_eq!(sequence_operation(add_acc, &[3, 4, 5]), 12);
+        assert_eq!(sequence_operation(add_acc, &[3, 4, 5]).unwrap(), 12);
     }
 
     #[test]
-    #[should_panic(expected = "tuple must have at least one element")]
-    fn sequence_operation_panics_on_empty_tuple() {
-        let _ = sequence_operation(add_acc, &Tuple::new());
+    fn sequence_operation_errors_on_empty_tuple() {
+        assert!(matches!(
+            sequence_operation(add_acc, &Tuple::new()),
+            Err(Error::EmptyTuple)
+        ));
     }
 }

--- a/src/constraints/cage/arithmetic.rs
+++ b/src/constraints/cage/arithmetic.rs
@@ -86,6 +86,7 @@ fn sequence_operation(f: impl Fn(M, N) -> M, t: &[N]) -> Result<M, Error> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -162,6 +162,8 @@ pub enum Error {
     DeltaSizeMismatch(Index, Index),
     /// An operation policy received an empty value slice.
     EmptyOpPolicyValues,
+    /// A tuple operation was applied to an empty slice.
+    EmptyTuple,
 }
 
 impl fmt::Display for Error {
@@ -215,6 +217,9 @@ impl fmt::Display for Error {
             ),
             Self::EmptyOpPolicyValues => {
                 write!(f, "operation policy received an empty value slice")
+            }
+            Self::EmptyTuple => {
+                write!(f, "tuple operation cannot be applied to an empty tuple")
             }
         }
     }
@@ -402,6 +407,10 @@ mod tests {
         assert_eq!(
             Error::EmptyOpPolicyValues.to_string(),
             "operation policy received an empty value slice"
+        );
+        assert_eq!(
+            Error::EmptyTuple.to_string(),
+            "tuple operation cannot be applied to an empty tuple"
         );
     }
 


### PR DESCRIPTION
## Summary
Refactored `sequence_operation` to return a `Result` type instead of panicking when given an empty tuple, improving error handling and making the function's failure modes explicit in its type signature.

## Key Changes
- Modified `sequence_operation` to return `Result<M, Error>` instead of `M`, replacing the panic with `Err(Error::EmptyTuple)`
- Added `Error::EmptyTuple` variant to the `Error` enum with appropriate Display implementation
- Updated the filter closure in `simplex_multisets` to use `is_ok_and()` to handle the Result return type
- Updated all call sites and tests to handle the Result type:
  - Test assertions now call `.unwrap()` on successful results
  - Panic test converted to assertion-based test checking for `Err(Error::EmptyTuple)`
- Removed `#[allow(clippy::panic)]` annotation as it's no longer needed

## Notable Details
- The error handling is integrated into the existing `Error` enum, maintaining consistency with other error types in the codebase
- The filter logic in `simplex_multisets` now uses `is_ok_and()` to elegantly handle both the Result type and the filtering condition in a single expression
- All existing functionality is preserved; this is purely a refactoring from panic-based to Result-based error handling

https://claude.ai/code/session_0162KJVoce5a7Hi4qQohpXXU