### PR TITLE
Add public iterator method to access puzzle cages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +130,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "kenken"
 version = "0.3.0"
 dependencies = [
+ "itertools",
  "rand",
  "rand_chacha",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ strum = { version = "0.28", features = ["derive"] }
 
 
 [dev-dependencies]
+itertools = "0.14"
 rand_chacha = "0.10.0"
 
 [lints.clippy]

--- a/src/constraints/all_different.rs
+++ b/src/constraints/all_different.rs
@@ -78,14 +78,14 @@ mod tests {
 
     #[test]
     fn row_contains_correct_cells() {
-        assert_eq!(
-            row_4().cells().collect::<Vec<_>>(),
-            vec![
+        itertools::assert_equal(
+            row_4().cells(),
+            [
                 Cell::new(2, 0),
                 Cell::new(2, 1),
                 Cell::new(2, 2),
-                Cell::new(2, 3)
-            ]
+                Cell::new(2, 3),
+            ],
         );
     }
 
@@ -98,9 +98,9 @@ mod tests {
 
     #[test]
     fn column_contains_correct_cells() {
-        assert_eq!(
-            column_3().cells().collect::<Vec<_>>(),
-            vec![Cell::new(0, 1), Cell::new(1, 1), Cell::new(2, 1)]
+        itertools::assert_equal(
+            column_3().cells(),
+            [Cell::new(0, 1), Cell::new(1, 1), Cell::new(2, 1)],
         );
     }
 

--- a/src/constraints/cage/arithmetic.rs
+++ b/src/constraints/cage/arithmetic.rs
@@ -92,122 +92,89 @@ mod tests {
 
     #[test]
     fn subtraction_multisets_target_1_min_1() {
-        assert_eq!(
-            subtraction_multisets(4, 1).collect::<Vec<_>>(),
-            vec![vec![1, 2], vec![2, 3], vec![3, 4]]
+        itertools::assert_equal(
+            subtraction_multisets(4, 1),
+            [vec![1, 2], vec![2, 3], vec![3, 4]],
         );
     }
 
     #[test]
     fn subtraction_multisets_target_2_min_1() {
-        assert_eq!(
-            subtraction_multisets(4, 2).collect::<Vec<_>>(),
-            vec![vec![1, 3], vec![2, 4]]
-        );
+        itertools::assert_equal(subtraction_multisets(4, 2), [vec![1, 3], vec![2, 4]]);
     }
 
     #[test]
     fn subtraction_multisets_no_results() {
-        assert_eq!(
-            subtraction_multisets(3, 5).collect::<Vec<_>>(),
-            Vec::<Tuple>::new()
-        );
+        itertools::assert_equal(subtraction_multisets(3, 5), Vec::<Tuple>::new());
     }
 
     #[test]
     fn division_multisets_target_2_min_1() {
-        assert_eq!(
-            division_multisets(4, 2).collect::<Vec<_>>(),
-            vec![vec![1, 2], vec![2, 4]]
-        );
+        itertools::assert_equal(division_multisets(4, 2), [vec![1, 2], vec![2, 4]]);
     }
 
     #[test]
     fn division_multisets_target_3_min_1() {
-        assert_eq!(
-            division_multisets(6, 3).collect::<Vec<_>>(),
-            vec![vec![1, 3], vec![2, 6]]
-        );
+        itertools::assert_equal(division_multisets(6, 3), [vec![1, 3], vec![2, 6]]);
     }
 
     #[test]
     fn division_multisets_no_results() {
-        assert_eq!(
-            division_multisets(5, 7).collect::<Vec<_>>(),
-            Vec::<Tuple>::new()
-        );
+        itertools::assert_equal(division_multisets(5, 7), Vec::<Tuple>::new());
     }
 
     #[test]
     fn simplex_multisets_filters_by_sum() {
         // k=2, n=4, sum=5: pairs are [1,4], [2,3]
-        assert_eq!(
-            addition_multisets(4, 2, 5).collect::<Vec<_>>(),
-            vec![vec![1, 4], vec![2, 3]]
-        );
+        itertools::assert_equal(addition_multisets(4, 2, 5), [vec![1, 4], vec![2, 3]]);
     }
 
     #[test]
     fn simplex_multisets_filters_by_product() {
         // k=2, n=6, product=6: pairs are [1,6], [2,3]
-        assert_eq!(
-            multiplication_multisets(6, 2, 6).collect::<Vec<_>>(),
-            vec![vec![1, 6], vec![2, 3]]
-        );
+        itertools::assert_equal(multiplication_multisets(6, 2, 6), [vec![1, 6], vec![2, 3]]);
     }
 
     #[test]
     fn addition_multisets_k3() {
         // n=4, k=3, s=6: [1,1,4], [1,2,3], [2,2,2]
-        assert_eq!(
-            addition_multisets(4, 3, 6).collect::<Vec<_>>(),
-            vec![vec![1, 1, 4], vec![1, 2, 3], vec![2, 2, 2]]
+        itertools::assert_equal(
+            addition_multisets(4, 3, 6),
+            [vec![1, 1, 4], vec![1, 2, 3], vec![2, 2, 2]],
         );
     }
 
     #[test]
     fn addition_multisets_no_results() {
         // s=1 with k=2 is impossible since min sum is 1+1=2
-        assert_eq!(
-            addition_multisets(4, 2, 1).collect::<Vec<_>>(),
-            Vec::<Tuple>::new()
-        );
+        itertools::assert_equal(addition_multisets(4, 2, 1), Vec::<Tuple>::new());
     }
 
     #[test]
     fn multiplication_multisets_k2() {
         // n=6, k=2, s=6: [1,6], [2,3]
-        assert_eq!(
-            multiplication_multisets(6, 2, 6).collect::<Vec<_>>(),
-            vec![vec![1, 6], vec![2, 3]]
-        );
+        itertools::assert_equal(multiplication_multisets(6, 2, 6), [vec![1, 6], vec![2, 3]]);
     }
 
     #[test]
     fn multiplication_multisets_k3() {
         // n=4, k=3, s=8: [1,2,4], [2,2,2]
-        assert_eq!(
-            multiplication_multisets(4, 3, 8).collect::<Vec<_>>(),
-            vec![vec![1, 2, 4], vec![2, 2, 2]]
+        itertools::assert_equal(
+            multiplication_multisets(4, 3, 8),
+            [vec![1, 2, 4], vec![2, 2, 2]],
         );
     }
 
     #[test]
     fn multiplication_multisets_no_results() {
         // s=7 is prime, so no factorization into 3 values in 1..=4
-        assert_eq!(
-            multiplication_multisets(4, 3, 7).collect::<Vec<_>>(),
-            Vec::<Tuple>::new()
-        );
+        itertools::assert_equal(multiplication_multisets(4, 3, 7), Vec::<Tuple>::new());
     }
 
     #[test]
     fn multiplication_multisets_large_product() {
         // 9^2 = 81 fits in N, but 9^3 = 729 does not — requires M
-        assert_eq!(
-            multiplication_multisets(9, 3, 729).collect::<Vec<_>>(),
-            vec![vec![9, 9, 9]]
-        );
+        itertools::assert_equal(multiplication_multisets(9, 3, 729), [vec![9, 9, 9]]);
     }
 
     fn add_acc(a: M, b: N) -> M {

--- a/src/constraints/polyomino.rs
+++ b/src/constraints/polyomino.rs
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn polyomino_cells_are_sorted() {
         let r = Polyomino::from_cells(&[c10(), c00(), c01()]).unwrap();
-        assert_eq!(r.cells().collect::<Vec<_>>(), vec![c00(), c01(), c10()]);
+        itertools::assert_equal(r.cells(), [c00(), c01(), c10()]);
     }
 
     #[test]
@@ -542,20 +542,17 @@ mod tests {
 
     #[test]
     fn permutations_single_element() {
-        assert_eq!(permutations(&[1]).collect::<Vec<_>>(), vec![vec![1]]);
+        itertools::assert_equal(permutations(&[1]), [vec![1]]);
     }
 
     #[test]
     fn permutations_two_distinct_elements() {
-        assert_eq!(
-            permutations(&[1, 2]).collect::<Vec<_>>(),
-            vec![vec![1, 2], vec![2, 1]]
-        );
+        itertools::assert_equal(permutations(&[1, 2]), [vec![1, 2], vec![2, 1]]);
     }
 
     #[test]
     fn permutations_two_equal_elements() {
-        assert_eq!(permutations(&[2, 2]).collect::<Vec<_>>(), vec![vec![2, 2]]);
+        itertools::assert_equal(permutations(&[2, 2]), [vec![2, 2]]);
     }
 
     #[test]

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -87,7 +87,8 @@ impl Puzzle {
         }
     }
 
-    /// Returns the puzzle's cages in the order defined by the storage.
+    /// Returns the puzzle's cages in ascending [`Cage`] order — by polyomino
+    /// cells (row-major), then operation, then tuples.
     pub fn cages(&self) -> impl Iterator<Item = &Cage> {
         self.cages.iter()
     }
@@ -264,8 +265,7 @@ mod tests {
             .insert(a.clone())
             .unwrap()
             .unwrap();
-        let collected: Vec<&Cage> = puzzle.cages().collect();
-        assert_eq!(collected, vec![&a, &b]);
+        itertools::assert_equal(puzzle.cages(), &[a, b]);
     }
 
     // --- Puzzle::branch ---

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -87,6 +87,11 @@ impl Puzzle {
         }
     }
 
+    /// Returns the puzzle's cages in the order defined by the storage.
+    pub fn cages(&self) -> impl Iterator<Item = &Cage> {
+        self.cages.iter()
+    }
+
     #[cfg(test)]
     pub const fn grid(&self) -> &Grid {
         &self.grid
@@ -230,6 +235,37 @@ mod tests {
         let p = puzzle_4();
         let p2 = p.remove(&singleton_cage());
         assert!(p2.insert(singleton_cage()).is_ok());
+    }
+
+    // --- Puzzle::cages ---
+
+    #[test]
+    fn cages_fresh_puzzle_is_empty() {
+        assert_eq!(puzzle_4().cages().count(), 0);
+    }
+
+    #[test]
+    fn cages_yields_in_storage_order() {
+        let a = Cage::new(
+            4,
+            Polyomino::from_cells(&cells(&[(0, 0)])).unwrap(),
+            Operation::Given(3),
+        );
+        let b = Cage::new(
+            4,
+            Polyomino::from_cells(&cells(&[(1, 1)])).unwrap(),
+            Operation::Given(2),
+        );
+        // Insert b first so storage order (BTreeSet by Cage::Ord) differs from insertion order.
+        let puzzle = puzzle_4()
+            .insert(b.clone())
+            .unwrap()
+            .unwrap()
+            .insert(a.clone())
+            .unwrap()
+            .unwrap();
+        let collected: Vec<&Cage> = puzzle.cages().collect();
+        assert_eq!(collected, vec![&a, &b]);
     }
 
     // --- Puzzle::branch ---

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -74,27 +74,21 @@ mod test {
     #[test]
     fn cage_valid_targets_yields_legal_targets_in_ascending_order() {
         let cells = [Cell::new(0, 0), Cell::new(0, 1)];
-        let subtract: Vec<Operation> = Polyomino::valid_operations(&cells, Operator::Subtract, 4)
-            .unwrap()
-            .collect();
-        assert_eq!(
-            subtract,
-            vec![
+        itertools::assert_equal(
+            Polyomino::valid_operations(&cells, Operator::Subtract, 4).unwrap(),
+            [
                 Operation::Subtract(1),
                 Operation::Subtract(2),
                 Operation::Subtract(3),
-            ]
+            ],
         );
-        let divide: Vec<Operation> = Polyomino::valid_operations(&cells, Operator::Divide, 4)
-            .unwrap()
-            .collect();
-        assert_eq!(
-            divide,
-            vec![
+        itertools::assert_equal(
+            Polyomino::valid_operations(&cells, Operator::Divide, 4).unwrap(),
+            [
                 Operation::Divide(2),
                 Operation::Divide(3),
                 Operation::Divide(4),
-            ]
+            ],
         );
     }
 


### PR DESCRIPTION
## Summary

Adds a public `Puzzle::cages()` iterator and, while in the area, sweeps the test suite to use `itertools::assert_equal` for iterator-vs-sequence comparisons.

## Changes

### `Puzzle::cages()` getter (`src/puzzle.rs`)

- New public method `pub fn cages(&self) -> impl Iterator<Item = &Cage>` that forwards the internal `BTreeSet<Cage>::iter()`.
- Yields cages in ascending `Cage` order — by polyomino cells (row-major), then operation, then tuples — as spelled out in the doc comment.
- Borrowed-reference iteration (`&Cage`) avoids cloning each cage's `Vec<Tuple>`.
- Two new unit tests: fresh puzzle yields nothing; iteration order matches storage order even when insertion order differs.

### Test ergonomics: `itertools::assert_equal` (18 sites)

- Added `itertools = "0.14"` to `[dev-dependencies]`.
- Replaced the `.collect::<Vec<_>>()` + `assert_eq!` pattern with `itertools::assert_equal(iter, expected)` across:
  - `src/puzzle.rs` (the new `cages_yields_in_storage_order` test)
  - `src/constraints/polyomino.rs` (`polyomino_cells_are_sorted`, three `permutations_*` tests)
  - `src/constraints/all_different.rs` (`row_contains_correct_cells`, `column_contains_correct_cells`)
  - `src/constraints/cage/arithmetic.rs` (twelve `*_multisets_*` tests)
  - `tests/public_api.rs` (`cage_valid_targets_yields_legal_targets_in_ascending_order`)
- Benefit: no intermediate `Vec`, and on failure the assertion pinpoints the first divergent index instead of dumping the whole vector.

## Test plan

- [x] `cargo test` — 183 unit + 8 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo doc --no-deps` — builds without warnings

https://claude.ai/code/session_01So359P4pwQ25SeokL7uK2N