### PR TITLE
Fix solver to recognize solutions and skip singleton cells

### DIFF
--- a/src/constraints/cage/mod.rs
+++ b/src/constraints/cage/mod.rs
@@ -52,11 +52,25 @@ impl Cage {
 }
 
 impl Constraint for Cage {
+    /// Applies generalized arc consistency: a tuple supports its cell-value
+    /// assignment only when every value still lies in its cell's current
+    /// domain. Each cell's new domain is the union of the values appearing at
+    /// that position across the *supported* tuples.
     fn apply_to(&self, grid: &Grid) -> Result<Grid, Error> {
         let n = self.len();
+        let current: Vec<Fill> = self
+            .cells()
+            .map(|c| grid.get(&c))
+            .collect::<Result<Vec<_>, _>>()?;
         let slots = self
             .tuples()
             .iter()
+            .filter(|tuple| {
+                tuple
+                    .iter()
+                    .zip(&current)
+                    .all(|(&val, fill)| !(*fill & Fill::new([val])).is_empty())
+            })
             .fold(vec![Fill::default(); n], |mut slots, tuple| {
                 for (slot, &val) in slots.iter_mut().zip(tuple.iter()) {
                     *slot = *slot | Fill::new([val]);

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -190,23 +190,31 @@ impl State for Puzzle {
         Ok(Some(puzzle))
     }
 
+    fn is_solved(&self) -> bool {
+        self.grid.is_solved()
+    }
+
     /// Returns one child puzzle per candidate value of the most-constrained
-    /// cell — the cell with the fewest remaining candidates, breaking ties by
-    /// cell order. Each child has that cell pinned to a single value.
+    /// *unsolved* cell — the cell with the fewest remaining candidates among
+    /// those with more than one candidate, breaking ties by cell order. Each
+    /// child has that cell pinned to a single value.
     ///
-    /// Returns an empty iterator if the grid has no cells, signaling a solution.
+    /// Returns an empty iterator when every cell is already a singleton.
     fn branch(&self) -> impl Iterator<Item = Self> {
-        self.grid
-            .most_constrained()
-            .into_iter()
-            .flat_map(move |(cell, fill)| {
-                let grid = self.grid.clone();
-                fill.iter().filter_map(move |v| {
-                    self.set_grid(grid.clone().set(&cell, Fill::new([v])))
-                        .ok()
-                        .flatten()
-                })
+        let pick = self
+            .grid
+            .cells()
+            .map(|cell| (cell, self.grid.get(&cell).unwrap_or_default()))
+            .filter(|(_, fill)| fill.len() > 1)
+            .min_by(|(a, fa), (b, fb)| fa.len().cmp(&fb.len()).then_with(|| a.cmp(b)));
+        pick.into_iter().flat_map(move |(cell, fill)| {
+            let grid = self.grid.clone();
+            fill.iter().filter_map(move |v| {
+                self.set_grid(grid.clone().set(&cell, Fill::new([v])))
+                    .ok()
+                    .flatten()
             })
+        })
     }
 }
 
@@ -408,28 +416,54 @@ mod tests {
     }
 
     #[test]
-    fn branch_after_given_cage_yields_one_child() {
-        // Given(3) pins (0,0) to {3}; it is the most-constrained cell (size 1).
+    fn branch_after_given_cage_skips_pinned_cell() {
+        // Given(3) pins (0,0) to {3}; AllDifferent narrows the other
+        // row-0 and column-0 cells to {1,2,4} (size 3). The most-constrained
+        // unsolved cell is (0,1) (size 3, first by row-major tie-break), so
+        // branch yields three children — one per remaining candidate.
         let puzzle = puzzle_4().insert(singleton_cage()).unwrap().unwrap();
-        assert_eq!(puzzle.branch().count(), 1);
+        assert_eq!(puzzle.branch().count(), 3);
     }
 
     #[test]
-    fn branch_children_pin_most_constrained_cell_to_distinct_singleton_values() {
+    fn branch_children_pin_branching_cell_to_distinct_singleton_values() {
+        // With (0,0)=3, branching happens on (0,1) ∈ {1,2,4}. Each child
+        // pins (0,1) to a different value.
         let puzzle = puzzle_4().insert(singleton_cage()).unwrap().unwrap();
         let mut values: Vec<Fill> = puzzle
             .branch()
-            .map(|child| {
-                let (_, fill) = child.grid().most_constrained().unwrap();
-                fill
-            })
+            .map(|child| child.grid().get(&Cell::new(0, 1)).unwrap())
             .collect();
-        // Each branch pins to exactly one value.
         assert!(values.iter().all(|f| f.len() == 1));
-        // All pinned values are distinct.
         values.sort_by_key(|f| f.iter().next().unwrap());
         values.dedup();
         assert_eq!(values.len(), puzzle.branch().count());
+    }
+
+    #[test]
+    fn branch_solved_puzzle_yields_no_children() {
+        // A 2×2 puzzle pinned by two non-overlapping Givens propagates to a
+        // fully-singleton grid. branch() must yield no children so the solver
+        // recognises the state as a solution.
+        let c1 = Cage::new(
+            2,
+            Polyomino::from_cells(&cells(&[(0, 0)])).unwrap(),
+            Operation::Given(1),
+        );
+        let c2 = Cage::new(
+            2,
+            Polyomino::from_cells(&cells(&[(0, 1)])).unwrap(),
+            Operation::Given(2),
+        );
+        let puzzle = Puzzle::new_empty(2)
+            .unwrap()
+            .insert(c1)
+            .unwrap()
+            .unwrap()
+            .insert(c2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(puzzle.branch().count(), 0);
     }
 
     // --- Puzzle::set_grid ---

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -201,6 +201,8 @@ impl State for Puzzle {
     ///
     /// Returns an empty iterator when every cell is already a singleton.
     fn branch(&self) -> impl Iterator<Item = Self> {
+        // Skip singletons: branching on a one-value fill would yield a child
+        // identical to the parent, so the solver would loop on it forever.
         let pick = self
             .grid
             .cells()

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -9,15 +9,18 @@ pub trait State: Sized {
     /// # Errors
     /// Returns [`Error`] if a constraint is applied to a cell outside the grid.
     fn propagate(&self) -> Result<Option<Self>, Error>;
-    /// Returns substates to explore. An empty iterator signals a solution.
+    /// Returns substates to explore.
     fn branch(&self) -> impl Iterator<Item = Self>;
+    /// Returns `true` when this state represents a complete solution. The
+    /// solver only yields states for which this is `true`.
+    fn is_solved(&self) -> bool;
 }
 
 /// A depth-first backtracking solver over any [`State`].
 ///
 /// Each call to [`Iterator::next`] returns one solution — a state for which
-/// [`State::branch`] yields no children. [`crate::Puzzle`] implements
-/// [`State`], so `Solver<Puzzle>` enumerates all solutions to a puzzle.
+/// [`State::is_solved`] is `true`. [`crate::Puzzle`] implements [`State`], so
+/// `Solver<Puzzle>` enumerates all solutions to a puzzle.
 pub struct Solver<S> {
     stack: Vec<S>,
 }
@@ -34,16 +37,13 @@ impl<S: State + Clone> Iterator for Solver<S> {
 
     fn next(&mut self) -> Option<S> {
         while let Some(state) = self.stack.pop() {
-            if let Ok(Some(state)) = state.propagate() {
-                let leaf_state = state.clone();
-                let mut branches = leaf_state.branch();
-                if let Some(first) = branches.next() {
-                    self.stack.push(first);
-                    self.stack.extend(branches);
-                } else {
-                    return Some(state);
-                }
+            let Ok(Some(state)) = state.propagate() else {
+                continue;
+            };
+            if state.is_solved() {
+                return Some(state);
             }
+            self.stack.extend(state.branch());
         }
         None
     }
@@ -107,6 +107,10 @@ mod tests {
                 })
             }
             .into_iter()
+        }
+
+        fn is_solved(&self) -> bool {
+            self.remaining == 1
         }
     }
 

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -40,6 +40,10 @@ impl<S: State + Clone> Iterator for Solver<S> {
             let Ok(Some(state)) = state.propagate() else {
                 continue;
             };
+            // is_solved is authoritative: a `State` is free to prune children
+            // inside branch(), so an empty branch iterator can mean either
+            // "no work left" or "all candidates were infeasible" — only the
+            // former is a solution.
             if state.is_solved() {
                 return Some(state);
             }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -5,8 +5,8 @@
 mod test {
 
     use kenken::{
-        Cage, Cell, Fill, Grid, Operation, Operator, Polyomino, Puzzle, Solver,
-        constraints::Cover, generate,
+        Cage, Cell, Fill, Grid, Operation, Operator, Polyomino, Puzzle, Solver, constraints::Cover,
+        generate,
     };
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -5,13 +5,80 @@
 mod test {
 
     use kenken::{
-        Cell, Fill, Grid, Operation, Operator, Polyomino, Puzzle, constraints::Cover, generate,
+        Cage, Cell, Fill, Grid, Operation, Operator, Polyomino, Puzzle, Solver,
+        constraints::Cover, generate,
     };
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
     fn rng(seed: u64) -> ChaCha8Rng {
         ChaCha8Rng::seed_from_u64(seed)
+    }
+
+    /// Builds a [`Cage`] over `cells` (given as `(row, column)` pairs) for an
+    /// `n`-sized grid.
+    fn cage(n: u8, cells: &[(usize, usize)], op: Operation) -> Cage {
+        let cells: Vec<Cell> = cells.iter().map(|&(r, c)| Cell::new(r, c)).collect();
+        Cage::new(n, Polyomino::from_cells(&cells).unwrap(), op)
+    }
+
+    /// A 6×6 puzzle fully covered by 18 vertical `Subtract(1)` pair cages,
+    /// one per column pair `((0,c)-(1,c))`, `((2,c)-(3,c))`, `((4,c)-(5,c))`.
+    ///
+    /// Each cage admits both orderings of every consecutive pair, so many
+    /// Latin-square completions satisfy the constraints.
+    fn multi_solution_puzzle() -> Puzzle {
+        let grid = Grid::new(6).unwrap();
+        let mut cages = Vec::with_capacity(18);
+        for col in 0..6 {
+            for (r0, r1) in [(0, 1), (2, 3), (4, 5)] {
+                cages.push(cage(6, &[(r0, col), (r1, col)], Operation::Subtract(1)));
+            }
+        }
+        Puzzle::new(&grid, &cages).unwrap().unwrap()
+    }
+
+    /// The [`multi_solution_puzzle`] layout with one cage swapped from
+    /// `Subtract(1)` to `Subtract(4)`. Initial propagation narrows
+    /// `(0,0)` and `(1,0)` to `{1, 2, 5, 6}` but cannot see the global
+    /// infeasibility: every assignment of column 0 leaves the remaining
+    /// four cells as `{2,3,4,6}` or `{1,3,4,5}`, neither of which can be
+    /// partitioned into two consecutive-integer pairs for the
+    /// `(2,0)-(3,0)` and `(4,0)-(5,0)` `Subtract(1)` cages.
+    fn no_solution_puzzle() -> Puzzle {
+        let grid = Grid::new(6).unwrap();
+        let mut cages = Vec::with_capacity(18);
+        cages.push(cage(6, &[(0, 0), (1, 0)], Operation::Subtract(4)));
+        for col in 0..6 {
+            let row_pairs: &[(usize, usize)] = if col == 0 {
+                &[(2, 3), (4, 5)]
+            } else {
+                &[(0, 1), (2, 3), (4, 5)]
+            };
+            for &(r0, r1) in row_pairs {
+                cages.push(cage(6, &[(r0, col), (r1, col)], Operation::Subtract(1)));
+            }
+        }
+        Puzzle::new(&grid, &cages).unwrap().unwrap()
+    }
+
+    #[test]
+    fn solver_finds_multiple_solutions_for_underconstrained_puzzle() {
+        let puzzle = multi_solution_puzzle();
+        let start = std::time::Instant::now();
+        let mut solver = Solver::new(puzzle);
+        assert!(solver.next().is_some());
+        assert!(solver.next().is_some());
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
+    }
+
+    #[test]
+    fn solver_finds_no_solutions_for_infeasible_puzzle() {
+        let puzzle = no_solution_puzzle();
+        let start = std::time::Instant::now();
+        let mut solver = Solver::new(puzzle);
+        assert!(solver.next().is_none());
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR fixes the solver's solution detection logic and improves the branching strategy to correctly handle solved puzzles and avoid infinite loops on singleton cells.

## Key Changes

- **Added `is_solved()` method to `State` trait**: The solver now explicitly checks if a state represents a complete solution, rather than inferring it from an empty branch iterator. This allows states to prune infeasible branches while still correctly identifying solutions.

- **Fixed `Puzzle::branch()` to skip singleton cells**: The branching logic now filters out cells with only one candidate value before selecting the most-constrained cell. This prevents the solver from creating child states identical to the parent, which would cause infinite loops.

- **Updated solver loop logic**: The `Solver::next()` method now uses `is_solved()` as the authoritative check for solutions, decoupling solution detection from branch availability. This correctly handles cases where branching prunes all candidates (infeasible) versus cases where all cells are already pinned (solved).

- **Improved constraint propagation in `Cage`**: The `apply_to()` method now implements generalized arc consistency by filtering tuples to only those supported by the current cell domains before computing new domains. This provides tighter constraint propagation.

- **Enhanced test coverage**: Added comprehensive tests including:
  - `branch_solved_puzzle_yields_no_children()`: Verifies that fully-solved puzzles produce no branches
  - `solver_finds_multiple_solutions_for_underconstrained_puzzle()`: Tests solver on underconstrained puzzles
  - `solver_finds_no_solutions_for_infeasible_puzzle()`: Tests solver correctly identifies infeasible puzzles

## Notable Implementation Details

- The branching cell selection now uses `filter(|(_, fill)| fill.len() > 1)` to skip singletons before applying `min_by()` to find the most-constrained unsolved cell.
- The solver's stack-based depth-first search now cleanly separates propagation failures (continue) from solution detection (is_solved check) from branching (extend stack).
- Constraint propagation now explicitly validates that each tuple's values remain in their respective cell domains before including them in the solution set.

https://claude.ai/code/session_011DnF9SN7p8wFMSJxsrpseS