### PR TITLE
Fix documentation grammar and simplify type imports in tests

### DIFF
--- a/src/generator/generate.rs
+++ b/src/generator/generate.rs
@@ -132,8 +132,8 @@ pub fn generate<R: Rng>(n: Index, rng: &mut R) -> Result<Option<Puzzle>, Error> 
 ///
 /// # Errors
 /// Returns `Error` if `n` is not in `1..=9`. The `?` on `insert` is
-/// structurally unreachable because the tiling's polyominos are disjoint, but
-/// is kept rather than panicking to avoid load-bearing assertions inside the
+/// structurally unreachable because the tiling's polyominos are disjoint but
+/// are kept rather than panicking to avoid load-bearing assertions inside the
 /// generator.
 ///
 /// # Panics
@@ -348,8 +348,7 @@ mod tests {
             let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
             let n = if seed % 3 == 0 { 4 } else { 3 };
             let tiling = greedy(n, dist, &mut rng).unwrap();
-            let covered: std::collections::HashSet<crate::Cell> =
-                tiling.iter().flat_map(Cover::cells).collect();
+            let covered: HashSet<Cell> = tiling.iter().flat_map(Cover::cells).collect();
             assert_eq!(covered.len(), n * n);
         }
     }


### PR DESCRIPTION
This PR includes minor documentation and code quality improvements to the generator module.

**Key changes:**
- Fixed grammar in the `insert_cell` function documentation by removing unnecessary comma and adjusting phrasing for clarity ("polyominos are disjoint but" instead of "polyominos are disjoint, but")
- Simplified type imports in the test module by using `HashSet` and `Cell` directly instead of fully qualified paths (`std::collections::HashSet` and `crate::Cell`)

These changes improve code readability and documentation accuracy without affecting functionality.

https://claude.ai/code/session_01EqXJG6qpo3geGypZdLJg1n