### PR TITLE
refactor: use imported Operation alias in Puzzle deserializer

### DIFF
--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -240,7 +240,7 @@ impl<'de> serde::Deserialize<'de> for Puzzle {
         #[derive(serde::Deserialize)]
         struct CageData {
             polyomino: crate::Polyomino,
-            operation: crate::constraints::cage::operation::Operation,
+            operation: Operation,
         }
         #[derive(serde::Deserialize)]
         struct PuzzleData {


### PR DESCRIPTION
## Summary

- Replace the fully-qualified `crate::constraints::cage::operation::Operation` path in the `Puzzle` deserializer's inline `CageData` struct with the already-imported `Operation` alias.

## Test plan

- [ ] `cargo test` passes (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)