### PR TITLE
refactor: replace #[allow(unused_results)] with let _ = at call sites

### DIFF
--- a/src/constraints/polyomino.rs
+++ b/src/constraints/polyomino.rs
@@ -87,10 +87,9 @@ impl Polyomino {
     /// # Errors
     /// Returns [`Error::DisconnectedPolyomino`] if adding `cell` would make the
     /// polyomino disconnected.
-    #[allow(unused_results)]
     pub fn insert(&self, cell: Cell) -> Result<Self, Error> {
         let mut cells = self.0.clone();
-        cells.insert(cell);
+        let _ = cells.insert(cell);
         Self::new(cells)
     }
 

--- a/src/constraints/regin.rs
+++ b/src/constraints/regin.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 
 use crate::types::{Fill, N};
 
-#[allow(clippy::similar_names, unused_results)]
+#[allow(clippy::similar_names)]
 pub fn regin(domains: &[Fill]) -> Vec<Fill> {
     let n = domains.len();
     if n == 0 {
@@ -64,6 +64,7 @@ pub fn regin(domains: &[Fill]) -> Vec<Fill> {
     let mut val_match: Vec<Option<usize>> = vec![None; num_values];
     let mut visited = vec![false; num_values];
 
+    #[allow(unused_results)]
     for var in 0..n {
         visited.fill(false);
         augment(
@@ -115,6 +116,11 @@ pub fn regin(domains: &[Fill]) -> Vec<Fill> {
 
 /// Tries to find an augmenting path from `var` using DFS.
 /// Returns true if the matching was extended.
+///
+/// Impure: mutates `var_match`, `val_match`, and `visited` in place. Making
+/// this pure would require cloning the matching vectors on every recursive
+/// call, since each frame reads and writes `val_match` to reassign values
+/// along the augmenting path.
 #[allow(clippy::similar_names)]
 fn augment(
     var: usize,
@@ -146,7 +152,7 @@ fn kosaraju_scc(adj: &[Vec<usize>], n: usize) -> Vec<usize> {
     let mut finish_order: Vec<usize> = Vec::with_capacity(n);
     for start in 0..n {
         if !visited[start] {
-            dfs_finish(start, adj, &mut visited, &mut finish_order);
+            finish_order.extend(dfs_finish(start, adj, &mut visited));
         }
     }
 
@@ -169,10 +175,10 @@ fn kosaraju_scc(adj: &[Vec<usize>], n: usize) -> Vec<usize> {
     comp
 }
 
-#[allow(unused_results)]
-fn dfs_finish(start: usize, adj: &[Vec<usize>], visited: &mut [bool], order: &mut Vec<usize>) {
+fn dfs_finish(start: usize, adj: &[Vec<usize>], visited: &mut [bool]) -> Vec<usize> {
     // Iterative to avoid stack overflow on large graphs.
     let mut stack: Vec<(usize, usize)> = vec![(start, 0)];
+    let mut order: Vec<usize> = vec![];
     visited[start] = true;
     while let Some((u, idx)) = stack.last_mut() {
         let u = *u;
@@ -185,11 +191,14 @@ fn dfs_finish(start: usize, adj: &[Vec<usize>], visited: &mut [bool], order: &mu
             }
         } else {
             order.push(u);
-            stack.pop();
+            let _ = stack.pop();
         }
     }
+    order
 }
 
+/// Impure: writes component labels into `comp` in place. The caller owns
+/// `comp` and passes it mutably so all SCC passes share one allocation.
 fn dfs_assign(start: usize, label: usize, radj: &[Vec<usize>], comp: &mut [usize]) {
     let mut stack = vec![start];
     comp[start] = label;

--- a/src/generator/generate.rs
+++ b/src/generator/generate.rs
@@ -168,7 +168,6 @@ where
 /// edge-connected uncovered cells until the target size sampled from
 /// `dist` is reached or no candidates remain, then starts a new
 /// polyomino.
-#[allow(unused_results)]
 pub fn greedy<R: Rng>(
     n: usize,
     dist: SizeDistribution,
@@ -186,7 +185,7 @@ pub fn greedy<R: Rng>(
         let target_size = dist.sample(n, rng);
 
         let mut cells: HashSet<Cell> = HashSet::new();
-        cells.insert(seed);
+        let _ = cells.insert(seed);
         // Frontier may contain duplicates; dedup happens on pop via the cells/covered
         // checks.
         let mut frontier: Vec<Cell> = grid_neighbors(seed, n)
@@ -207,7 +206,7 @@ pub fn greedy<R: Rng>(
         }
 
         for c in &cells {
-            covered.insert(*c);
+            let _ = covered.insert(*c);
         }
         let cells: Vec<Cell> = cells.into_iter().collect();
         // `cells` is non-empty (the seed is always inserted) and

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -95,7 +95,6 @@ impl Puzzle {
     /// # Errors
     /// Returns [`CageConflict`] if `cage` overlaps any cage already in
     /// the puzzle not identical to `cage`.
-    #[allow(unused_results)]
     pub fn insert(&self, cage: Cage) -> Result<Option<Self>, Error> {
         if self.cages.contains(&cage) {
             return Ok(Some(self.clone()));
@@ -108,7 +107,7 @@ impl Puzzle {
             return Err(CageConflict(cage));
         }
         let mut cages = self.cages.clone();
-        cages.insert(cage);
+        let _ = cages.insert(cage);
         Self {
             grid: self.grid.clone(),
             all_different: self.all_different.clone(),


### PR DESCRIPTION
## Summary

- Replace three broad `#[allow(unused_results)]` suppressions on `Polyomino::insert`, `Puzzle::insert`, and `greedy` with targeted `let _ =` discards at the specific `BTreeSet::insert` and `stack.pop()` call sites where the return value is intentionally ignored
- Rewrite `dfs_finish` in `regin.rs` to return its finish order (`Vec<usize>`) instead of mutating a passed-in `Vec`, eliminating the need for its function-level suppression
- Add doc comments on `augment` and `dfs_assign` explaining why they remain impure and why making them pure would be impractical

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo build` produces no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)