### PR TITLE
Expose candidates() method and Fill type in public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,4 @@ pub use constraints::{
 pub use generator::generate::SizeDistribution;
 pub(crate) use grid::Grid;
 pub use puzzle::Puzzle;
-pub(crate) use types::Fill;
-pub use types::{Cell, Error};
+pub use types::{Cell, Error, Fill};

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -150,6 +150,16 @@ impl Puzzle {
         self.cages.iter()
     }
 
+    /// Returns each cell paired with its current candidate [`Fill`], in
+    /// row-major order. Every `Puzzle` is propagated to a fixpoint, so each
+    /// `Fill` is as narrow as the constraints require; for a solved puzzle,
+    /// every `Fill` is a singleton.
+    pub fn candidates(&self) -> impl Iterator<Item = (Cell, Fill)> {
+        self.grid
+            .cells()
+            .map(|cell| (cell, self.grid.get(&cell).unwrap_or_default()))
+    }
+
     /// Enumerates the puzzle's solutions via depth-first backtracking search.
     ///
     /// Each item is a fully solved [`Puzzle`] (every cell pinned to one value).
@@ -499,6 +509,35 @@ mod tests {
             .unwrap()
             .unwrap();
         itertools::assert_equal(puzzle.cages(), &[a, b]);
+    }
+
+    // --- Puzzle::candidates ---
+
+    #[test]
+    fn candidates_fresh_puzzle_yields_n_squared_pairs_with_full_fills() {
+        let puzzle = puzzle_4();
+        let pairs: Vec<(Cell, Fill)> = puzzle.candidates().collect();
+        assert_eq!(pairs.len(), 16);
+        assert!(pairs.iter().all(|(_, f)| *f == Fill::full(4)));
+    }
+
+    #[test]
+    fn candidates_iterates_in_row_major_order() {
+        let cells: Vec<Cell> = puzzle_4().candidates().map(|(c, _)| c).collect();
+        let expected: Vec<Cell> = (0..4)
+            .flat_map(|r| (0..4).map(move |c| Cell::new(r, c)))
+            .collect();
+        assert_eq!(cells, expected);
+    }
+
+    #[test]
+    fn candidates_reflects_pinned_cell_after_given_cage() {
+        let puzzle = puzzle_4().insert(singleton_cage()).unwrap().unwrap();
+        let (_, fill) = puzzle
+            .candidates()
+            .find(|(c, _)| *c == Cell::new(0, 0))
+            .unwrap();
+        assert_eq!(fill, Fill::new([3]));
     }
 
     // --- Puzzle::branch ---

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::unwrap_used)]
 mod test {
 
-    use kenken::{Cage, Cell, Operation, Polyomino, Puzzle, SizeDistribution};
+    use kenken::{Cage, Cell, Fill, Operation, Polyomino, Puzzle, SizeDistribution};
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
@@ -190,5 +190,22 @@ mod test {
         let p = Polyomino::from_cells(&[cell(0, 0), cell(0, 1), cell(1, 0)]).unwrap();
         let cage = Cage::new(4, p, Operation::Add(6));
         assert_eq!(cage.len(), 3);
+    }
+
+    #[test]
+    fn candidates_exposes_cell_fill_pairs_via_public_api() {
+        // Given(2) at (0,0) pins that cell to {2}; the remaining cells in row 0
+        // and column 0 narrow to {1, 3, 4} via AllDifferent.
+        let puzzle = Puzzle::with_cages(4, &[cage(4, &[(0, 0)], Operation::Given(2))])
+            .unwrap()
+            .unwrap();
+        let pairs: Vec<(Cell, Fill)> = puzzle.candidates().collect();
+        assert_eq!(pairs.len(), 16);
+        let pinned = pairs
+            .iter()
+            .find(|(c, _)| *c == cell(0, 0))
+            .map(|(_, f)| *f)
+            .unwrap();
+        assert_eq!(pinned, Fill::new([2]));
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a new public `candidates()` method to the `Puzzle` type and exports the `Fill` type, enabling users to inspect the current candidate values for each cell in a puzzle.

## Key Changes
- **New `Puzzle::candidates()` method**: Returns an iterator of `(Cell, Fill)` pairs in row-major order, where each `Fill` represents the current set of candidate values for that cell. The puzzle is always propagated to a fixpoint, so candidates are as narrow as constraints allow.
- **Public `Fill` type export**: Changed `Fill` from internal-only (`pub(crate)`) to public, allowing users to work with candidate sets directly.
- **Comprehensive test coverage**: Added three unit tests in `puzzle.rs` validating that:
  - Fresh puzzles yield full candidate sets for all cells
  - Candidates are iterated in row-major order
  - Pinned cells (from given cages) correctly reflect their singleton fills
- **Public API test**: Added integration test in `tests/public_api.rs` demonstrating the feature through the public API with a concrete example.

## Implementation Details
The `candidates()` method leverages the existing `Grid` infrastructure, mapping over all cells and retrieving their current `Fill` values. The implementation is straightforward and non-invasive, simply exposing internal state that was already being maintained.

https://claude.ai/code/session_01CB4XQ53EqamVAX1pBKTV7t