### PR TITLE
refactor: store puzzle cages as CageSlot variants

### DIFF
--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -155,8 +155,9 @@ impl Puzzle {
         .unwrap_or_else(|| unreachable!("widening fills cannot produce a contradiction")))
     }
 
-    /// Returns the puzzle's cages in ascending [`Cage`] order — by polyomino
-    /// cells (row-major), then operation, then tuples.
+    /// Returns the puzzle's cages in ascending order by polyomino cells
+    /// (row-major). The puzzle invariant guarantees no two stored cages share
+    /// a polyomino, so ties never arise.
     pub fn cages(&self) -> impl Iterator<Item = &Cage> {
         self.slots.iter().filter_map(CageSlot::as_cage)
     }
@@ -482,6 +483,20 @@ mod tests {
         let p = puzzle_4();
         let p2 = p.remove(&singleton_cage()).unwrap();
         assert!(p2.insert(singleton_cage()).is_ok());
+    }
+
+    #[test]
+    fn remove_same_polyomino_different_operation_is_noop() {
+        // CageSlot::Ord matches on polyomino alone, so naive BTreeSet::remove
+        // would drop the existing cage even when the operation differs.
+        // remove() must guard with value equality and leave the puzzle intact.
+        let original = singleton_cage(); // Given(3) at (0,0)
+        let p = puzzle_4().insert(original.clone()).unwrap().unwrap();
+        let other_op = Cage::new(4, singleton(), Operation::Given(2));
+        let p2 = p.remove(&other_op).unwrap();
+        // The original Given(3) cage is still enforced.
+        assert_eq!(p2.grid().get(&Cell::new(0, 0)).unwrap(), Fill::new([3]));
+        itertools::assert_equal(p2.cages(), &[original]);
     }
 
     #[test]

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 #[cfg(feature = "generate")]
 use crate::generator::generate::{SizeDistribution, default_op_policy, generate, generate_with};
 use crate::{
-    Cage, Cell, Cover, Error,
+    Cage, CageSlot, Cell, Cover, Error,
     Error::{CageConflict, CageNotInPuzzle},
     Fill, Grid,
     constraints::{Constraint, all_different::AllDifferent, cage::operation::Operation},
@@ -34,7 +34,7 @@ use crate::{
 pub struct Puzzle {
     grid: Grid,
     all_different: Vec<AllDifferent>,
-    cages: BTreeSet<Cage>,
+    slots: BTreeSet<CageSlot>,
 }
 
 impl Puzzle {
@@ -47,7 +47,7 @@ impl Puzzle {
         Ok(Self {
             grid: grid.clone(),
             all_different: grid.all_different_constraints()?,
-            cages: BTreeSet::default(),
+            slots: BTreeSet::default(),
         })
     }
 
@@ -67,7 +67,7 @@ impl Puzzle {
         Self {
             grid: grid.clone(),
             all_different: grid.all_different_constraints()?,
-            cages: cages.iter().cloned().collect(),
+            slots: cages.iter().cloned().map(CageSlot::Cage).collect(),
         }
         .propagate()
     }
@@ -83,7 +83,7 @@ impl Puzzle {
         Self {
             grid,
             all_different: self.all_different.clone(),
-            cages: self.cages.clone(),
+            slots: self.slots.clone(),
         }
         .propagate()
     }
@@ -98,22 +98,26 @@ impl Puzzle {
     /// Returns [`CageConflict`] if `cage` overlaps any cage already in
     /// the puzzle not identical to `cage`.
     pub fn insert(&self, cage: Cage) -> Result<Option<Self>, Error> {
-        if self.cages.contains(&cage) {
-            return Ok(Some(self.clone()));
-        }
-        if self
-            .cages
+        // CageSlot's Ord compares by polyomino only, so any slot whose polyomino
+        // intersects the new cage's is a candidate for either idempotency or
+        // conflict — distinguish by exact value equality.
+        match self
+            .slots
             .iter()
-            .any(|puzzle_cage| puzzle_cage.polyomino().intersects(cage.polyomino()))
+            .find(|s| s.polyomino().intersects(cage.polyomino()))
         {
-            return Err(CageConflict(cage));
+            Some(CageSlot::Cage(existing)) if existing == &cage => {
+                return Ok(Some(self.clone()));
+            }
+            Some(CageSlot::Cage(_) | CageSlot::Region(_)) => return Err(CageConflict(cage)),
+            None => {}
         }
-        let mut cages = self.cages.clone();
-        let _ = cages.insert(cage);
+        let mut slots = self.slots.clone();
+        let _ = slots.insert(CageSlot::Cage(cage));
         Self {
             grid: self.grid.clone(),
             all_different: self.all_different.clone(),
-            cages,
+            slots,
         }
         .propagate()
     }
@@ -129,15 +133,20 @@ impl Puzzle {
     /// # Errors
     /// Returns [`Error`] if propagation encounters a cell outside the grid bounds.
     pub fn remove(&self, cage: &Cage) -> Result<Self, Error> {
-        let mut cages = self.cages.clone();
-        if !cages.remove(cage) {
+        // CageSlot::Ord matches on polyomino alone; require exact value equality
+        // before removing so a different-operation cage on the same polyomino
+        // stays a no-op.
+        let key = CageSlot::Cage(cage.clone());
+        if self.slots.get(&key) != Some(&key) {
             return Ok(self.clone());
         }
+        let mut slots = self.slots.clone();
+        let _ = slots.remove(&key);
         let n = self.grid.n();
         Ok(Self {
             grid: Grid::new(n)?,
             all_different: self.all_different.clone(),
-            cages,
+            slots,
         }
         .propagate()?
         // Safe: Grid::new(n) succeeds because n came from a valid Puzzle (n in 1..=9),
@@ -149,7 +158,7 @@ impl Puzzle {
     /// Returns the puzzle's cages in ascending [`Cage`] order — by polyomino
     /// cells (row-major), then operation, then tuples.
     pub fn cages(&self) -> impl Iterator<Item = &Cage> {
-        self.cages.iter()
+        self.slots.iter().filter_map(CageSlot::as_cage)
     }
 
     /// Returns each cell paired with its current candidate [`Fill`], in
@@ -233,7 +242,7 @@ impl Puzzle {
         self.all_different
             .iter()
             .map(|c| c as &dyn Constraint)
-            .chain(self.cages.iter().map(|c| c as &dyn Constraint))
+            .chain(self.cages().map(|c| c as &dyn Constraint))
             .try_fold(self.grid.clone(), |grid, c| c.apply_to(&grid))
             .map(|grid| (!grid.is_invalid()).then_some(grid))
     }
@@ -244,7 +253,7 @@ impl serde::Serialize for Puzzle {
         use serde::ser::SerializeStruct;
         let mut st = s.serialize_struct("Puzzle", 2)?;
         st.serialize_field("n", &self.grid.n())?;
-        st.serialize_field("cages", &self.cages.iter().collect::<Vec<_>>())?;
+        st.serialize_field("cages", &self.cages().collect::<Vec<_>>())?;
         st.end()
     }
 }


### PR DESCRIPTION
## Summary

- Replace `Puzzle.cages: BTreeSet<Cage>` with `Puzzle.slots: BTreeSet<CageSlot>` (issue #74, stage 1 of the slot model).
- Every slot stored here is a `CageSlot::Cage` variant, so the public API (`cages()`, `insert`, `remove`, `with_cages`) and the JSON wire format (`{"cages": [...Cage]}`) are unchanged.
- Because `CageSlot::Ord` compares by polyomino alone, `insert` distinguishes idempotency from conflict via exact value equality, and `remove` confirms the matching polyomino's slot is value-equal before removing — preserving the prior no-op semantics for absent or different-operation cages.

The new region API and the save-format migration are deferred to follow-up issues, per #74.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features` with the CI lint set (warnings, pedantic, nursery, unwrap/expect/panic denied)
- [x] `cargo test --all-features` — all 241 tests pass without modification
- [x] `cargo test --no-default-features --lib --tests` — wasm-friendly build path
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`

Closes #74.

https://claude.ai/code/session_0137DZY9K8gLo4oesqcZyKSP

---
_Generated by [Claude Code](https://claude.ai/code/session_0137DZY9K8gLo4oesqcZyKSP)_