### PR TITLE
fix: guard Polyomino::valid_tuples against arity mismatch (#82)

### DIFF
--- a/src/constraints/cage/mod.rs
+++ b/src/constraints/cage/mod.rs
@@ -223,4 +223,18 @@ mod tests {
             assert!(Cage::new(4, p, op).tuples().is_empty());
         }
     }
+
+    #[test]
+    fn cage_new_with_mismatched_operator_arity_yields_no_tuples() {
+        for (p, op) in [
+            (pair(), Operation::Given(1)),
+            (l_shape(), Operation::Given(1)),
+            (singleton(), Operation::Subtract(1)),
+            (l_shape(), Operation::Subtract(1)),
+            (singleton(), Operation::Divide(2)),
+            (l_shape(), Operation::Divide(2)),
+        ] {
+            assert!(Cage::new(4, p, op).tuples().is_empty());
+        }
+    }
 }

--- a/src/constraints/polyomino.rs
+++ b/src/constraints/polyomino.rs
@@ -205,6 +205,14 @@ impl Polyomino {
     /// polyomino on an `n`×`n` grid.
     pub(crate) fn valid_tuples(&self, n: N, operation: Operation) -> Vec<Tuple> {
         let k = self.len();
+        let arity_ok = match operation {
+            Operation::Given(_) => k == 1,
+            Operation::Subtract(_) | Operation::Divide(_) => k == 2,
+            Operation::Add(_) | Operation::Multiply(_) => true,
+        };
+        if !arity_ok {
+            return vec![];
+        }
         let pairs = self.collinear_pairs();
         match operation {
             Operation::Given(v) => N::try_from(v)


### PR DESCRIPTION
## Summary

Fixes #82. `Cage::new(n, polyomino, op)` panicked with an index-out-of-bounds inside `ordered_tuples` when the operator's multiset arity didn't match the polyomino's cell count:

- `Operation::Given(_)` on ≠ 1-cell polyomino
- `Operation::Subtract(_)` / `Operation::Divide(_)` on ≠ 2-cell polyomino

…as soon as `collinear_pairs()` produced a pair referencing an index past the multiset length (true for almost every wrong-sized polyomino).

The fix in `Polyomino::valid_tuples` is an upfront arity check that returns an empty `Vec` for mismatched operations, aligning with the "empty tuples = infeasible" contract `Puzzle::promote` (#75) wants to rely on.

## Changes

- `src/constraints/polyomino.rs`: arity check before `collinear_pairs()` and the main multiset match.
- `src/constraints/cage/mod.rs`: new test `cage_new_with_mismatched_operator_arity_yields_no_tuples` covering each (operator, wrong-arity polyomino) combination from the issue.

## Test plan

- [x] `cargo test` — 227 unit + 16 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New test asserts `Cage::new(4, l_shape(), Operation::Subtract(1)).tuples().is_empty()` (the reproducer from the issue) returns rather than panicking.

## Follow-ups

- The workaround `Polyomino::valid_operators(&cells).contains(&Operator::of(op))` check in `Puzzle::promote` (#75) is now redundant and can be dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4dGH2XSFtTvfW8ftNNWQb)_