### PR TITLE
feat: add Puzzle::with_slots constructor for mixed Region/Cage input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exposing the edge-connectivity check used during polyomino construction.
 - `Cage::cells()` and `Cage::len()` — accessors that delegate to the underlying
   polyomino.
+- `Puzzle::with_slots(n, &[CageSlot])` — bulk constructor accepting mixed
+  `Region` and `Cage` slots, the generalization of `with_cages`. Validates
+  slot bounds and rejects duplicate polyominoes, then propagates to fixpoint.
+- `Error::DuplicateSlotPolyomino(Polyomino)` — raised by `with_slots` (and the
+  `Puzzle` deserializer) when two slots share the same polyomino.
+
+### Changed
+- `Puzzle::with_cages` is now a thin wrapper around `Puzzle::with_slots`.
+- `Error::CageNotInPuzzle(Cage)` renamed to `Error::SlotNotInPuzzle(CageSlot)`
+  to cover both cage and region out-of-bounds cases.
 
 ## [0.3.0] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `Puzzle::with_cages` is now a thin wrapper around `Puzzle::with_slots`.
+- `Puzzle::with_cages` now returns `Error::DuplicateSlotPolyomino` when two
+  cages share a polyomino. Previously these silently collapsed in the
+  puzzle's slot set.
 - `Error::CageNotInPuzzle(Cage)` renamed to `Error::SlotNotInPuzzle(CageSlot)`
   to cover both cage and region out-of-bounds cases.
 

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -10,7 +10,9 @@ use rand::Rng;
 use crate::generator::generate::{SizeDistribution, default_op_policy, generate, generate_with};
 use crate::{
     Cage, CageSlot, Cell, Cover, Error,
-    Error::{CageConflict, CageNotInPuzzle, InfeasibleOperation, RegionConflict},
+    Error::{
+        CageConflict, DuplicateSlotPolyomino, InfeasibleOperation, RegionConflict, SlotNotInPuzzle,
+    },
     Fill, Grid, Polyomino,
     constraints::{Constraint, all_different::AllDifferent, cage::operation::Operation},
     solver::solve::{Solver, State},
@@ -56,20 +58,45 @@ impl Puzzle {
     /// Creates an `n`×`n` puzzle from a set of cages, then propagates
     /// all constraints. Returns `None` if propagation finds a contradiction.
     ///
+    /// Thin wrapper around [`Puzzle::with_slots`] for the common case of a
+    /// fully-operated puzzle (no draft regions).
+    ///
     /// # Errors
     /// Returns [`Error::InvalidGridSize`] if `n` is not in `1..=9`.
-    /// Returns [`CageNotInPuzzle`] if any cage contains a cell outside the grid.
+    /// Returns [`SlotNotInPuzzle`] if any cage contains a cell outside the grid.
+    /// Returns [`DuplicateSlotPolyomino`] if two cages share a polyomino.
     pub fn with_cages(n: usize, cages: &[Cage]) -> Result<Option<Self>, Error> {
+        let slots: Vec<CageSlot> = cages.iter().cloned().map(CageSlot::Cage).collect();
+        Self::with_slots(n, &slots)
+    }
+
+    /// Creates an `n`×`n` puzzle from a set of [`CageSlot`]s (mixed
+    /// [`CageSlot::Region`]s and [`CageSlot::Cage`]s), then propagates all
+    /// constraints. Returns `None` if propagation finds a contradiction.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidGridSize`] if `n` is not in `1..=9`.
+    /// Returns [`SlotNotInPuzzle`] if any slot covers a cell outside the grid.
+    /// Returns [`DuplicateSlotPolyomino`] if two slots share the same polyomino:
+    /// [`CageSlot::cmp`] keys on the polyomino alone, so distinct slots over the
+    /// same polyomino would silently collide in the puzzle's slot set.
+    pub fn with_slots(n: usize, slots: &[CageSlot]) -> Result<Option<Self>, Error> {
         let grid = Grid::new(n)?;
-        for cage in cages {
-            if cage.cells().any(|c| c.row >= n || c.column >= n) {
-                return Err(CageNotInPuzzle(cage.clone()));
+        for slot in slots {
+            if slot.cells().any(|c| c.row >= n || c.column >= n) {
+                return Err(SlotNotInPuzzle(slot.clone()));
+            }
+        }
+        let mut seen = BTreeSet::new();
+        for slot in slots {
+            if !seen.insert(slot.polyomino()) {
+                return Err(DuplicateSlotPolyomino(slot.polyomino().clone()));
             }
         }
         Self {
             grid: grid.clone(),
             all_different: grid.all_different_constraints()?,
-            slots: cages.iter().cloned().map(CageSlot::Cage).collect(),
+            slots: slots.iter().cloned().collect(),
         }
         .propagate()
     }
@@ -388,36 +415,9 @@ impl<'de> serde::Deserialize<'de> for Puzzle {
             slots: Vec<CageSlot>,
         }
         let PuzzleData { n, slots } = PuzzleData::deserialize(d)?;
-        let grid = Grid::new(n).map_err(serde::de::Error::custom)?;
-        for slot in &slots {
-            if slot.cells().any(|c| c.row >= n || c.column >= n) {
-                return Err(serde::de::Error::custom(
-                    "slot covers a cell outside the grid",
-                ));
-            }
-        }
-        // Reject same-polyomino duplicates at the wire-format boundary. Two slots over
-        // the same polyomino would violate the Puzzle invariant; relying on BTreeSet to
-        // dedupe is unsafe because CageSlot's Ord and PartialEq deliberately disagree.
-        let mut seen_polys = BTreeSet::new();
-        for slot in &slots {
-            if !seen_polys.insert(slot.polyomino()) {
-                return Err(serde::de::Error::custom(
-                    "puzzle slots contain duplicate polyominoes",
-                ));
-            }
-        }
-        let all_different = grid
-            .all_different_constraints()
-            .map_err(serde::de::Error::custom)?;
-        Self {
-            grid,
-            all_different,
-            slots: slots.into_iter().collect(),
-        }
-        .propagate()
-        .map_err(serde::de::Error::custom)?
-        .ok_or_else(|| serde::de::Error::custom("puzzle slots produce a contradiction"))
+        Self::with_slots(n, &slots)
+            .map_err(serde::de::Error::custom)?
+            .ok_or_else(|| serde::de::Error::custom("puzzle slots produce a contradiction"))
     }
 }
 
@@ -513,8 +513,88 @@ mod tests {
         );
         assert!(matches!(
             Puzzle::with_cages(1, &[out_of_bounds]),
-            Err(Error::CageNotInPuzzle(_))
+            Err(Error::SlotNotInPuzzle(CageSlot::Cage(_)))
         ));
+    }
+
+    // --- Puzzle::with_slots ---
+
+    #[test]
+    fn with_slots_no_slots_returns_some() {
+        let puzzle = Puzzle::with_slots(4, &[]).unwrap().unwrap();
+        assert_eq!(puzzle.slots().count(), 0);
+    }
+
+    #[test]
+    fn with_slots_mixed_regions_and_cages_succeeds() {
+        // Region at (0,0), Cage with Given(2) at (1,1) — distinct polyominoes.
+        let region = Polyomino::from_cells(&cells(&[(0, 0)])).unwrap();
+        let cage = Cage::new(
+            4,
+            Polyomino::from_cells(&cells(&[(1, 1)])).unwrap(),
+            Operation::Given(2),
+        );
+        let puzzle =
+            Puzzle::with_slots(4, &[CageSlot::Region(region), CageSlot::Cage(cage.clone())])
+                .unwrap()
+                .unwrap();
+        assert_eq!(puzzle.regions().count(), 1);
+        itertools::assert_equal(puzzle.cages(), &[cage]);
+        // The cage's Given(2) propagates and pins (1,1) to {2}.
+        assert_eq!(puzzle.grid().get(&Cell::new(1, 1)).unwrap(), Fill::new([2]));
+    }
+
+    #[test]
+    fn with_slots_region_outside_grid_returns_err() {
+        // A region whose only cell sits outside a 2×2 grid.
+        let region = Polyomino::from_cells(&cells(&[(5, 0)])).unwrap();
+        assert!(matches!(
+            Puzzle::with_slots(2, &[CageSlot::Region(region)]),
+            Err(Error::SlotNotInPuzzle(CageSlot::Region(_)))
+        ));
+    }
+
+    #[test]
+    fn with_slots_cage_outside_grid_returns_err() {
+        let cage = Cage::new(
+            4,
+            Polyomino::from_cells(&cells(&[(0, 0), (0, 1)])).unwrap(),
+            Operation::Add(3),
+        );
+        assert!(matches!(
+            Puzzle::with_slots(1, &[CageSlot::Cage(cage)]),
+            Err(Error::SlotNotInPuzzle(CageSlot::Cage(_)))
+        ));
+    }
+
+    #[test]
+    fn with_slots_duplicate_polyomino_returns_err() {
+        // A Region and a Cage over the same polyomino: CageSlot::Ord matches by
+        // polyomino, so the BTreeSet would silently drop one. The constructor
+        // must reject upfront.
+        let cage = Cage::new(4, singleton(), Operation::Given(3));
+        let slots = [CageSlot::Region(singleton()), CageSlot::Cage(cage)];
+        assert!(matches!(
+            Puzzle::with_slots(4, &slots),
+            Err(Error::DuplicateSlotPolyomino(_))
+        ));
+    }
+
+    #[test]
+    fn with_slots_contradicting_cages_returns_none() {
+        // Two Given(1) cages in the same row of a 2×2 grid is a contradiction.
+        let c1 = Cage::new(
+            2,
+            Polyomino::from_cells(&cells(&[(0, 0)])).unwrap(),
+            Operation::Given(1),
+        );
+        let c2 = Cage::new(
+            2,
+            Polyomino::from_cells(&cells(&[(0, 1)])).unwrap(),
+            Operation::Given(1),
+        );
+        let slots = [CageSlot::Cage(c1), CageSlot::Cage(c2)];
+        assert!(Puzzle::with_slots(2, &slots).unwrap().is_none());
     }
 
     #[test]

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -648,6 +648,19 @@ mod tests {
     }
 
     #[test]
+    fn with_cages_duplicate_polyomino_returns_err() {
+        // Two cages over the same polyomino used to silently collapse in the
+        // slot set (CageSlot::Ord matches by polyomino only); via with_slots
+        // the constructor now rejects them.
+        let c1 = Cage::new(4, singleton(), Operation::Given(3));
+        let c2 = Cage::new(4, singleton(), Operation::Given(2));
+        assert!(matches!(
+            Puzzle::with_cages(4, &[c1, c2]),
+            Err(Error::DuplicateSlotPolyomino(_))
+        ));
+    }
+
+    #[test]
     fn n() {
         assert_eq!(puzzle_4().n(), 4);
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::constraints::{
     cage::{Cage, operation::Operation},
+    cage_slot::CageSlot,
     polyomino::Polyomino,
 };
 
@@ -146,8 +147,14 @@ pub enum Error {
     InvalidCell(Cell),
     /// A new [`Cage`] conflicts with an existing cage.
     CageConflict(Cage),
-    /// A [`Cage`] passed to a `Puzzle` method is not present in that puzzle.
-    CageNotInPuzzle(Cage),
+    /// A [`CageSlot`] passed to a `Puzzle` constructor covers cells outside the
+    /// grid, so it cannot belong to that puzzle.
+    SlotNotInPuzzle(CageSlot),
+    /// Two slots passed to a `Puzzle` constructor share the same
+    /// [`Polyomino`]. Allowed shapes must be distinct: storing both would
+    /// silently collide in the puzzle's slot set ([`CageSlot::cmp`] keys on the
+    /// polyomino).
+    DuplicateSlotPolyomino(Polyomino),
     /// A new region [`Polyomino`] conflicts with an existing slot in the puzzle.
     RegionConflict(Polyomino),
     /// A [`Polyomino`] cannot support the requested [`Operation`]: either the
@@ -193,7 +200,13 @@ impl fmt::Display for Error {
                     "cage {new:?} conflicts with an existing cage in the puzzle"
                 )
             }
-            Self::CageNotInPuzzle(cage) => write!(f, "cage {cage:?} is not in this puzzle"),
+            Self::SlotNotInPuzzle(slot) => match slot {
+                CageSlot::Cage(c) => write!(f, "cage {c:?} is not in this puzzle"),
+                CageSlot::Region(p) => write!(f, "region {p:?} is not in this puzzle"),
+            },
+            Self::DuplicateSlotPolyomino(p) => {
+                write!(f, "duplicate polyomino {p:?} across puzzle slots")
+            }
             Self::RegionConflict(p) => write!(
                 f,
                 "region {p:?} conflicts with an existing slot in the puzzle"
@@ -419,7 +432,7 @@ mod tests {
 
     #[test]
     fn error_display_cage_and_region_variants() {
-        use crate::{Cage, Error, Operation, constraints::polyomino::Polyomino};
+        use crate::{Cage, CageSlot, Error, Operation, constraints::polyomino::Polyomino};
         let p = Polyomino::from_cells(&[Cell::new(0, 0)]).unwrap();
         let cage = Cage::new(4, p.clone(), Operation::Given(1));
         assert!(
@@ -427,10 +440,16 @@ mod tests {
                 .to_string()
                 .contains("conflicts")
         );
+        let cage_msg = Error::SlotNotInPuzzle(CageSlot::Cage(cage)).to_string();
+        assert!(cage_msg.starts_with("cage "));
+        assert!(cage_msg.contains("not in this puzzle"));
+        let region_msg = Error::SlotNotInPuzzle(CageSlot::Region(p.clone())).to_string();
+        assert!(region_msg.starts_with("region "));
+        assert!(region_msg.contains("not in this puzzle"));
         assert!(
-            Error::CageNotInPuzzle(cage)
+            Error::DuplicateSlotPolyomino(p.clone())
                 .to_string()
-                .contains("not in this puzzle")
+                .contains("duplicate polyomino")
         );
         assert!(
             Error::RegionConflict(p.clone())


### PR DESCRIPTION
## Summary

Closes #76 by adding the last missing piece called out in that issue: a `Puzzle::with_slots(n, &[CageSlot])` constructor. Prior PRs (#79, #81, #85, #86) already moved the `Puzzle` storage to `BTreeSet<CageSlot>`, repointed serde at the `slots` field, and added the region API.

- `Puzzle::with_slots(n: usize, slots: &[CageSlot]) -> Result<Option<Self>, Error>` accepts mixed `Region` and `Cage` slots, validates bounds and duplicate polyominoes, then propagates to fixpoint.
- `Puzzle::with_cages` is now a thin wrapper that maps each `Cage` into `CageSlot::Cage` and delegates.
- The `Puzzle` deserializer's hand-rolled validation (bounds check + duplicate-polyomino guard + struct assembly + propagate) collapses into a single call to `with_slots`, so the wire-format boundary and the programmatic constructor share one implementation.
- `Error::CageNotInPuzzle(Cage)` is renamed to `Error::SlotNotInPuzzle(CageSlot)` (one variant covers both cage and region out-of-bounds cases). A new `Error::DuplicateSlotPolyomino(Polyomino)` replaces the deserializer's former string error for the same-polyomino case — necessary because `CageSlot::Ord` keys on the polyomino alone, so a naive `BTreeSet` collect would silently drop one slot.

## Test plan

- [x] `bash .githooks/pre-commit` — fmt, the full pedantic+nursery clippy config, and rustdoc with `-D warnings` all pass.
- [x] `cargo test --all-features` — 258 unit tests + 21 public-API integration tests pass, including five new `with_slots_*` cases (mixed regions/cages, region out-of-bounds, cage out-of-bounds, duplicate polyomino, contradicting cages) and an updated `with_cages_cage_outside_grid_returns_err` that now asserts `SlotNotInPuzzle(CageSlot::Cage(_))`.
- [x] `cargo build --no-default-features` — wasm-friendly build still compiles.
- [x] Existing `puzzle_round_trips_with_regions_preserved` already exercises the end-to-end serialize → deserialize path; it now flows through `with_slots`.

Designer-side bump of `SaveEnvelope.version` (mentioned in the issue) lives in a separate repo and is out of scope for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyX7VQAYpwof3B9N9Dmcsj)_