### PR TITLE
feat: derive Serialize/Deserialize on Operator (#88)

### DIFF
--- a/src/constraints/cage/operation.rs
+++ b/src/constraints/cage/operation.rs
@@ -24,7 +24,9 @@ pub enum Operation {
 /// Used by `Cage::valid_operators` to enumerate the operators legal for a cage
 /// shape, and by `Cage::valid_targets` to select an operator for which to
 /// enumerate legal targets.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, EnumIter)]
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, Hash, EnumIter, serde::Serialize, serde::Deserialize,
+)]
 pub enum Operator {
     Add,
     Subtract,
@@ -42,6 +44,23 @@ impl Operator {
             Operation::Multiply(_) => Self::Multiply,
             Operation::Divide(_) => Self::Divide,
             Operation::Given(_) => Self::Given,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    #[test]
+    fn operator_round_trips_through_json() {
+        for op in Operator::iter() {
+            let json = serde_json::to_string(&op).unwrap();
+            let restored: Operator = serde_json::from_str(&json).unwrap();
+            assert_eq!(op, restored);
         }
     }
 }


### PR DESCRIPTION
Closes #88.

## Summary

- Adds `serde::Serialize` and `serde::Deserialize` to `Operator` at `src/constraints/cage/operation.rs:27`, matching the derives already on the sibling `Operation` enum.
- Adds a round-trip test that exercises all variants via `Operator::iter()`, mirroring the `*_round_trips_through_json` pattern already used by `Puzzle` (`src/puzzle.rs:1188`), `CageSlot`, and `Region`.

## Why

`Operator` is `Copy` and fieldless; the derive is trivial. The asymmetry with `Operation` was forcing downstream consumers (notably `wpm/kenken-designer`'s Tauri `cage_options` command, which sends `Vec<CageOption { op: Operator, targets: Vec<u32> }>` to a wasm frontend) to maintain a parallel `OpKind` mirror enum solely to add the derives. Landing this unblocks `wpm/kenken-designer#118`, which deletes that mirror.

## Test plan

- [x] `cargo test` — new `operator_round_trips_through_json` test passes, full suite green.
- [x] `.githooks/pre-commit` — `cargo fmt --all`, `cargo clippy` (with pedantic/nursery + `unwrap_used`/`expect_used`/`panic` denies), and `cargo doc` all clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BLoJC3Z2o6UuY2Tj1AEUdE)_