### PR TITLE
refactor: remove `generate` Cargo feature, make generation unconditional

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ cargo fmt --all
 git add -u
 
 echo "==> cargo clippy"
-cargo clippy --all-targets --all-features -- \
+cargo clippy --all-targets -- \
   -D warnings \
   -D clippy::all \
   -D clippy::pedantic \
@@ -25,6 +25,6 @@ cargo clippy --all-targets --all-features -- \
   2>&1
 
 echo "==> cargo doc"
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps 2>&1
 
 echo "==> Pre-commit checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Clippy
         run: |
-          cargo clippy --all-targets --all-features -- \
+          cargo clippy --all-targets -- \
             -D warnings \
             -D clippy::all \
             -D clippy::pedantic \
@@ -44,7 +44,7 @@ jobs:
             -D clippy::print_stderr
 
       - name: Test
-        run: cargo llvm-cov --all-features --lcov --output-path lcov.info --fail-under-lines 99
+        run: cargo llvm-cov --lcov --output-path lcov.info --fail-under-lines 99
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
@@ -53,18 +53,7 @@ jobs:
           slug: wpm/KenKen
           files: lcov.info
 
-      - name: Wasm build (no default features)
-        # rustup target add (not dtolnay's `targets:` field) is what installs the
-        # wasm target onto the toolchain that rust-toolchain.toml selects; the
-        # action's input would install it onto the wrong toolchain.
-        run: |
-          rustup target add wasm32-unknown-unknown
-          cargo build --target wasm32-unknown-unknown --no-default-features
-
-      - name: Test (no default features)
-        run: cargo test --no-default-features --lib --tests
-
       - name: Doc
-        run: cargo doc --no-deps --all-features
+        run: cargo doc --no-deps
         env:
           RUSTDOCFLAGS: -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Error::CageNotInPuzzle(Cage)` renamed to `Error::SlotNotInPuzzle(CageSlot)`
   to cover both cage and region out-of-bounds cases.
 
+### Removed
+- `generate` Cargo feature — generation is now unconditional and `rand`
+  is a required dependency.
+
 ## [0.3.0] - 2026-05-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,8 @@ categories = ["games"]
 readme = "README.md"
 exclude = [".githooks", ".github"]
 
-[features]
-default = ["generate"]
-generate = ["dep:rand"]
-
 [dependencies]
-rand = { version = "0.10.1", optional = true }
+rand = "0.10.1"
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,11 @@
 //!   bulk-construct with [`Puzzle::with_cages`].
 //! - Enumerate solutions with [`Puzzle::solve`].
 //! - Generate a random puzzle with [`Puzzle::generate`] (or [`Puzzle::generate_with`] for a custom
-//!   operation policy and cage-size distribution). Requires the `generate` feature, which is on by
-//!   default; disable it (e.g. with `--no-default-features`) for wasm-friendly builds that ship no
-//!   `rand`/`getrandom` code.
+//!   operation policy and cage-size distribution).
 
 #![allow(clippy::must_use_candidate, clippy::return_self_not_must_use)]
-#![cfg_attr(not(feature = "generate"), allow(rustdoc::broken_intra_doc_links))]
 
 mod constraints;
-#[cfg(feature = "generate")]
 mod generator;
 mod grid;
 mod puzzle;
@@ -29,7 +25,6 @@ pub use constraints::{
     cage_slot::CageSlot,
     polyomino::Polyomino,
 };
-#[cfg(feature = "generate")]
 pub use generator::generate::SizeDistribution;
 pub(crate) use grid::Grid;
 pub use puzzle::Puzzle;

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -3,11 +3,8 @@
 
 use std::collections::BTreeSet;
 
-#[cfg(feature = "generate")]
 use rand::Rng;
 
-#[cfg(feature = "generate")]
-use crate::generator::generate::{SizeDistribution, default_op_policy, generate, generate_with};
 use crate::{
     Cage, CageSlot, Cell, Cover, Error,
     Error::{
@@ -15,6 +12,7 @@ use crate::{
     },
     Fill, Grid, Polyomino,
     constraints::{Constraint, all_different::AllDifferent, cage::operation::Operation},
+    generator::generate::{SizeDistribution, default_op_policy, generate, generate_with},
     solver::solve::{Solver, State},
 };
 
@@ -334,7 +332,6 @@ impl Puzzle {
     ///
     /// # Errors
     /// Returns [`Error::InvalidGridSize`] if `n` is not in `1..=9`.
-    #[cfg(feature = "generate")]
     pub fn generate<R: Rng>(n: usize, rng: &mut R) -> Result<Self, Error> {
         generate(n, rng)
     }
@@ -349,7 +346,6 @@ impl Puzzle {
     /// # Errors
     /// Returns [`Error::InvalidGridSize`] if `n` is not in `1..=9`, or any
     /// error returned by `op`.
-    #[cfg(feature = "generate")]
     pub fn generate_with<R: Rng, F>(
         n: usize,
         rng: &mut R,
@@ -371,7 +367,6 @@ impl Puzzle {
     ///
     /// # Errors
     /// Returns [`Error::EmptyOpPolicyValues`] if `values` is empty.
-    #[cfg(feature = "generate")]
     pub fn default_op_policy(values: &[u8], n: usize) -> Result<Operation, Error> {
         default_op_policy(values, n)
     }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -92,7 +92,6 @@ mod test {
         assert_eq!(puzzle.solve().count(), 1);
     }
 
-    #[cfg(feature = "generate")]
     mod generator {
         use kenken::{Puzzle, SizeDistribution};
         use rand::SeedableRng;


### PR DESCRIPTION
## Summary

- Delete the `generate` Cargo feature (and its default-on toggle); make `rand` a required dependency. Random puzzle generation is now unconditional.
- Strip every `#[cfg(feature = "generate")]` gate from `src/lib.rs`, `src/puzzle.rs`, and `tests/public_api.rs`, plus the paired `#[cfg_attr(not(feature = "generate"), allow(rustdoc::broken_intra_doc_links))]` in `src/lib.rs` (which **closes #80**).
- Drop the wasm/no-default-features CI matrix slice and the now-meaningless `--all-features` flags from CI and the pre-commit hook.
- Update the crate-level doc bullet and add a `CHANGELOG.md` `### Removed` entry.

## Why

The `generate` feature was added in #78 to let wasm builds opt out of pulling in `rand`/`getrandom`. Generation is what the crate is *for*, the toggle complicated the public API and crate docs, and the `--no-default-features` CI slice did little more than prove the gate compiled. Removing it deletes more code than it adds.

## Test plan

- [x] `.githooks/pre-commit` clean (fmt, full clippy lint set, `cargo doc -D warnings`)
- [x] `cargo test` — all 21 integration + unit tests pass, including `tests/public_api.rs::test::generator::*`
- [ ] CI green end-to-end on this branch (fmt, clippy, tests + 99% coverage, doc)
- [ ] Issue #80 closes automatically on merge

https://claude.ai/code/session_01LT3DZD4jvayS1YCPtDYQkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LT3DZD4jvayS1YCPtDYQkU)_