### PR TITLE
feat: add Puzzle::remove_region(&Polyomino)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Puzzle::with_slots(n, &[CageSlot])` — bulk constructor accepting mixed
   `Region` and `Cage` slots, the generalization of `with_cages`. Validates
   slot bounds and rejects duplicate polyominoes, then propagates to fixpoint.
+- `Puzzle::remove_region(&Polyomino)` — symmetric inverse of
+  `insert_region`. Idempotent on absent polyomino; variant-strict, so a
+  cage on the same polyomino stays put.
 - `Error::DuplicateSlotPolyomino(Polyomino)` — raised by `with_slots` (and the
   `Puzzle` deserializer) when two slots share the same polyomino.
 

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -220,6 +220,34 @@ impl Puzzle {
         })
     }
 
+    /// Returns a new [`Puzzle`] with the region at `polyomino` removed.
+    /// Regions contribute no propagation, so the grid is unchanged.
+    ///
+    /// This is idempotent. Attempting to remove a region that is not present
+    /// returns the puzzle unchanged. If a *cage* (not a region) exists at
+    /// `polyomino`, this is also a no-op — callers must
+    /// [`demote`](Self::demote) first.
+    ///
+    /// # Errors
+    /// None today — region removal cannot widen domains into a contradiction.
+    /// Returns `Result<Self, Error>` for signature symmetry with
+    /// [`remove`](Self::remove) and to leave room for future propagation work.
+    pub fn remove_region(&self, polyomino: &Polyomino) -> Result<Self, Error> {
+        // CageSlot::Ord matches on polyomino alone; require Region-variant
+        // value equality so a cage on the same polyomino stays a no-op.
+        let key = CageSlot::Region(polyomino.clone());
+        if self.slots.get(&key) != Some(&key) {
+            return Ok(self.clone());
+        }
+        let mut slots = self.slots.clone();
+        let _ = slots.remove(&key);
+        Ok(Self {
+            grid: self.grid.clone(),
+            all_different: self.all_different.clone(),
+            slots,
+        })
+    }
+
     /// Returns a new [`Puzzle`] with the region at `polyomino` replaced by a
     /// cage carrying `op`, then re-propagated.
     ///

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -289,4 +289,66 @@ mod test {
         assert_eq!(slots.len(), 1);
         assert!(matches!(slots[0], CageSlot::Region(_)));
     }
+
+    #[test]
+    fn remove_region_removes_present_region() {
+        let p = region(&[(0, 0)]);
+        let puzzle = Puzzle::new(4)
+            .unwrap()
+            .insert_region(p.clone())
+            .unwrap()
+            .remove_region(&p)
+            .unwrap();
+        assert_eq!(puzzle.regions().count(), 0);
+        assert_eq!(puzzle.slots().count(), 0);
+    }
+
+    #[test]
+    fn remove_region_absent_is_noop() {
+        let puzzle = Puzzle::new(4).unwrap();
+        let after = puzzle.remove_region(&region(&[(0, 0)])).unwrap();
+        assert_eq!(after.slots().count(), 0);
+    }
+
+    #[test]
+    fn remove_region_on_cage_polyomino_is_noop() {
+        let c = cage(4, &[(0, 0)], Operation::Given(3));
+        let puzzle = Puzzle::new(4).unwrap().insert(c).unwrap().unwrap();
+        let after = puzzle.remove_region(&region(&[(0, 0)])).unwrap();
+        assert_eq!(after.cages().count(), 1);
+        assert_eq!(after.regions().count(), 0);
+    }
+
+    #[test]
+    fn remove_region_preserves_grid_candidates() {
+        let p = region(&[(0, 0)]);
+        let puzzle = Puzzle::new(4)
+            .unwrap()
+            .insert_region(p.clone())
+            .unwrap()
+            .remove_region(&p)
+            .unwrap();
+        assert_eq!(
+            puzzle
+                .candidates()
+                .find(|(c, _)| *c == cell(0, 0))
+                .unwrap()
+                .1,
+            Fill::full(4)
+        );
+    }
+
+    #[test]
+    fn remove_region_then_insert_region_round_trips() {
+        let p = region(&[(0, 0)]);
+        let base = Puzzle::new(4).unwrap().insert_region(p.clone()).unwrap();
+        let round_tripped = base
+            .remove_region(&p)
+            .unwrap()
+            .insert_region(p.clone())
+            .unwrap();
+        let base_regions: Vec<&Polyomino> = base.regions().collect();
+        let round_tripped_regions: Vec<&Polyomino> = round_tripped.regions().collect();
+        assert_eq!(base_regions, round_tripped_regions);
+    }
 }


### PR DESCRIPTION
## Summary

Adds `Puzzle::remove_region(&Polyomino)` as the symmetric inverse of `insert_region`, completing the region lifecycle (`insert_region` / `promote` / `demote` / `remove_region`). Needed by [kenken-designer #119](https://github.com/wpm/kenken-designer/issues/119) so the "user discards a draft region" flow can be expressed without rebuilding the whole puzzle via `with_slots`.

- **Idempotent on absent polyomino** — returns `self.clone()`.
- **Variant-strict** — a `CageSlot::Cage` at the same polyomino is a no-op (callers must `demote` first), mirroring the value-equality guard in `remove(&Cage)` at `src/puzzle.rs:167`.
- **No grid mutation, no propagation** — regions are excluded from `apply_constraints`, so the inverse is purely structural.

## Test plan

- [x] `cargo test --all-targets` — 5 new public-API tests pass (`remove_region_removes_present_region`, `remove_region_absent_is_noop`, `remove_region_on_cage_polyomino_is_noop`, `remove_region_preserves_grid_candidates`, `remove_region_then_insert_region_round_trips`).
- [x] `.githooks/pre-commit` — `cargo fmt`, strict clippy (`-D pedantic -D nursery -D unwrap_used …`), and `cargo doc -D warnings` all pass.

Closes #93.

---
_Generated by [Claude Code](https://claude.ai/code/session_013DLSFvCQj8QwY2GKU23g1H)_