### PR TITLE
feat: add Operation::target() accessor (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `Operation::target()` — returns the operation's target value, symmetric
+  with `Operator::of(Operation)`.
 - `Polyomino::cells()` — iterates the polyomino's cells in row-major order.
 - `Polyomino::len()` — number of cells (O(1)).
 - `Polyomino::contains(Cell)` — membership test (O(log n)).

--- a/src/constraints/cage/operation.rs
+++ b/src/constraints/cage/operation.rs
@@ -19,6 +19,19 @@ pub enum Operation {
     Given(M),
 }
 
+impl Operation {
+    /// Returns the operation's target value.
+    pub const fn target(&self) -> M {
+        match *self {
+            Self::Add(t)
+            | Self::Subtract(t)
+            | Self::Multiply(t)
+            | Self::Divide(t)
+            | Self::Given(t) => t,
+        }
+    }
+}
+
 /// The operator portion of an [`Operation`], without an associated target.
 ///
 /// Used by `Cage::valid_operators` to enumerate the operators legal for a cage
@@ -62,5 +75,14 @@ mod tests {
             let restored: Operator = serde_json::from_str(&json).unwrap();
             assert_eq!(op, restored);
         }
+    }
+
+    #[test]
+    fn operation_target_returns_associated_value() {
+        assert_eq!(Operation::Add(7).target(), 7);
+        assert_eq!(Operation::Subtract(3).target(), 3);
+        assert_eq!(Operation::Multiply(12).target(), 12);
+        assert_eq!(Operation::Divide(4).target(), 4);
+        assert_eq!(Operation::Given(9).target(), 9);
     }
 }


### PR DESCRIPTION
## Summary

Adds `Operation::target() -> M`, the symmetric accessor to the existing `Operator::of(Operation) -> Operator`. Consumers no longer need to pattern-match on every variant or maintain a local `target_of` helper.

Closes #91.

## Changes

- `src/constraints/cage/operation.rs`: new `pub const fn Operation::target(&self) -> M` plus a unit test covering all five variants (`Add`, `Subtract`, `Multiply`, `Divide`, `Given`).
- `CHANGELOG.md`: entry under `[Unreleased]` → `Added`.

## Downstream

Once released, wpm/kenken-designer#130 can delete its duplicate `target_of` helpers in `kenken-designer/src/operation.rs` and `kenken-designer/src-tauri/src/view.rs` and call `op.target().into()` instead.

## Test plan

- [x] `.githooks/pre-commit` passes (`cargo fmt`, `cargo clippy` with the strict lint set, `cargo doc -D warnings`)
- [x] `cargo test` — all 261 existing tests plus the new `operation_target_returns_associated_value` pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01QoBt669FRpSANUgdvnPgSY)_