### PR TITLE
feat: add CageOption and Polyomino::feasible_options (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Polyomino::contains(Cell)` — membership test (O(log n)).
 - `Polyomino::is_edge_connected_component(&[Cell])` — associated function
   exposing the edge-connectivity check used during polyomino construction.
+- `CageOption { op: Operator, targets: Vec<u16> }` — aggregated operator and
+  feasible targets for a cage shape. Derives `Debug, Clone, Eq, PartialEq,
+  Hash, Serialize, Deserialize`.
+- `Polyomino::feasible_options(n)` — returns the `CageOption`s legal for
+  this polyomino on an `n`×`n` grid. Composes `valid_operators` and
+  `valid_operations`, so it skips the tuple materialization that
+  `operator_tuples` performs.
 - `Cage::cells()` and `Cage::len()` — accessors that delegate to the underlying
   polyomino.
 - `Puzzle::with_slots(n, &[CageSlot])` — bulk constructor accepting mixed

--- a/src/constraints/cage/operation.rs
+++ b/src/constraints/cage/operation.rs
@@ -61,6 +61,16 @@ impl Operator {
     }
 }
 
+/// A feasible operator paired with every target that produces a non-empty
+/// tuple set for a given polyomino on a given grid size.
+///
+/// Returned by [`crate::Polyomino::feasible_options`].
+#[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CageOption {
+    pub op: Operator,
+    pub targets: Vec<M>,
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -84,5 +94,16 @@ mod tests {
         assert_eq!(Operation::Multiply(12).target(), 12);
         assert_eq!(Operation::Divide(4).target(), 4);
         assert_eq!(Operation::Given(9).target(), 9);
+    }
+
+    #[test]
+    fn cage_option_round_trips_through_json() {
+        let opt = CageOption {
+            op: Operator::Add,
+            targets: vec![3, 4, 5],
+        };
+        let json = serde_json::to_string(&opt).unwrap();
+        let restored: CageOption = serde_json::from_str(&json).unwrap();
+        assert_eq!(opt, restored);
     }
 }

--- a/src/constraints/polyomino.rs
+++ b/src/constraints/polyomino.rs
@@ -10,6 +10,7 @@ use crate::{
                 addition_multisets, division_multisets, multiplication_multisets,
                 subtraction_multisets,
             },
+            operation::CageOption,
         },
     },
     types::{Index, M, N},
@@ -171,6 +172,28 @@ impl Polyomino {
                 }))
             }
         })
+    }
+
+    /// Returns the operator/target combinations that produce non-empty tuple
+    /// sets when applied to this polyomino on an `n`×`n` grid.
+    ///
+    /// Each [`CageOption`] aggregates one operator with all targets it
+    /// admits after collinearity filtering. Operators with no admissible
+    /// targets are omitted. Operators appear in the order returned by
+    /// [`Self::valid_operators`]; targets within each entry are in
+    /// ascending order.
+    pub fn feasible_options(&self, n: N) -> Vec<CageOption> {
+        let cells: Vec<Cell> = self.cells().collect();
+        Self::valid_operators(&cells)
+            .into_iter()
+            .filter_map(|op| {
+                let targets: Vec<M> = Self::valid_operations(&cells, op, n)
+                    .ok()?
+                    .map(|operation| operation.target())
+                    .collect();
+                (!targets.is_empty()).then_some(CageOption { op, targets })
+            })
+            .collect()
     }
 
     /// Returns true if `operation` is legal for a cage of the given cells on an
@@ -797,6 +820,59 @@ mod tests {
             .collect();
         assert!(!got.contains(&Operation::Multiply(1)));
         assert!(got.contains(&Operation::Multiply(2)));
+    }
+
+    // --- feasible_options ---
+
+    #[test]
+    fn feasible_options_singleton_returns_only_given() {
+        let got = singleton().feasible_options(4);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].op, Operator::Given);
+        assert_eq!(got[0].targets, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn feasible_options_pair_same_row_returns_four_operators() {
+        let got = pair().feasible_options(4);
+        let ops: Vec<Operator> = got.iter().map(|o| o.op).collect();
+        assert_eq!(
+            ops,
+            vec![
+                Operator::Add,
+                Operator::Subtract,
+                Operator::Multiply,
+                Operator::Divide,
+            ]
+        );
+        let by_op = |op: Operator| {
+            got.iter()
+                .find(|o| o.op == op)
+                .map(|o| o.targets.clone())
+                .unwrap_or_default()
+        };
+        // n=4 same row: Add(2) requires [1,1] (filtered); Multiply(1) requires [1,1] (filtered).
+        assert!(!by_op(Operator::Add).contains(&2));
+        assert!(by_op(Operator::Add).contains(&3));
+        assert!(!by_op(Operator::Multiply).contains(&1));
+        assert_eq!(by_op(Operator::Subtract), vec![1, 2, 3]);
+        assert_eq!(by_op(Operator::Divide), vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn feasible_options_three_cells_returns_add_and_multiply_only() {
+        let got = row3().feasible_options(4);
+        let ops: Vec<Operator> = got.iter().map(|o| o.op).collect();
+        assert_eq!(ops, vec![Operator::Add, Operator::Multiply]);
+    }
+
+    #[test]
+    fn feasible_options_never_returns_empty_targets() {
+        for poly in [singleton(), pair(), col_pair(), row3(), l_shape()] {
+            for opt in poly.feasible_options(4) {
+                assert!(!opt.targets.is_empty(), "empty targets for {:?}", opt.op);
+            }
+        }
     }
 
     // --- collinear_pairs ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub(crate) use constraints::Cover;
 pub use constraints::{
     cage::{
         Cage, Tuple,
-        operation::{Operation, Operator},
+        operation::{CageOption, Operation, Operator},
     },
     cage_slot::CageSlot,
     polyomino::Polyomino,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::unwrap_used)]
 mod test {
 
-    use kenken::{Cage, CageSlot, Cell, Fill, Operation, Polyomino, Puzzle};
+    use kenken::{Cage, CageOption, CageSlot, Cell, Fill, Operation, Operator, Polyomino, Puzzle};
 
     const fn cell(row: usize, column: usize) -> Cell {
         Cell::new(row, column)
@@ -183,6 +183,17 @@ mod test {
     #[test]
     fn is_edge_connected_component_treats_empty_input_as_connected() {
         assert!(Polyomino::is_edge_connected_component(&[]));
+    }
+
+    #[test]
+    fn polyomino_feasible_options_is_publicly_callable() {
+        let p = region(&[(0, 0), (0, 1)]);
+        let opts = p.feasible_options(4);
+        assert!(opts.iter().any(|o| matches!(o.op, Operator::Add)));
+        assert!(opts.iter().all(|o| !o.targets.is_empty()));
+        let json = serde_json::to_string(&opts).unwrap();
+        let restored: Vec<CageOption> = serde_json::from_str(&json).unwrap();
+        assert_eq!(opts, restored);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #92.

Hosts the `(operator, feasible targets)` aggregation in the `kenken` crate so the kenken-designer backend's `cage_options` Tauri command can become a passthrough and the parallel `CageOption` struct can be deleted from both the Designer backend and its frontend (downstream: wpm/kenken-designer#124).

- New `CageOption { op: Operator, targets: Vec<u16> }` in `src/constraints/cage/operation.rs` (next to `Operator`/`Operation`). Derives `Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize`.
- New `Polyomino::feasible_options(n: u8) -> Vec<CageOption>` in `src/constraints/polyomino.rs`. Composes the existing `valid_operators` + `valid_operations`, so it skips the tuple materialization that `operator_tuples` performs.
- Re-exported `CageOption` from `lib.rs`.
- Added a `CHANGELOG.md` entry under `[Unreleased] ### Added`. No version bump — leaving that for a release PR.

### Decisions (vs. issue's "subject to revision" proposal)
- `targets: Vec<u16>` (matches `M` used everywhere else in the public API) instead of `Vec<u32>`. The Designer can upcast in one place for its wire format.
- Signature takes `n: u8` since target ranges depend on grid size; every sibling enumerator already takes `n`.
- Operators with no admissible targets are filtered out so callers never see a degenerate `CageOption`.

## Test plan

- [x] `cargo test` — 265 unit + 27 integration tests pass
- [x] `.githooks/pre-commit` — fmt, clippy (pedantic/nursery + unwrap/expect/panic/todo/unimplemented denied), `cargo doc -D warnings` all clean
- [x] Added unit tests in `polyomino.rs` covering singleton/pair/3-cell shapes and the never-empty-targets invariant
- [x] Added JSON round-trip test for `CageOption`
- [x] Added public-API visibility test in `tests/public_api.rs` (calls `feasible_options` and round-trips the result through serde)

https://claude.ai/code/session_019V2hfFFapt2z2cdCWoa9U3

---
_Generated by [Claude Code](https://claude.ai/code/session_019V2hfFFapt2z2cdCWoa9U3)_