### PR TITLE
Pumpkin migration step 3: generalized Régin all-different propagator (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     a custom STR cage `Propagator` per cage. `Engine::solve` and
     `Engine::enumerate(limit)` agree with the bespoke solver on solvable and
     uniquely-solvable puzzles.
+  - Step 3 wraps the generalized `regin` (from #97) as a custom `Propagator`
+    and uses it for every row and column in place of the built-in pairwise
+    `all_different`, giving the engine full GAC all-different. Confirmed
+    Hall-set pruning on the 4×4 line and pigeonhole conflict detection.
 
 ## [0.3.0] - 2026-05-17
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -15,6 +15,7 @@
 #![allow(dead_code, unused_imports)]
 
 mod cage_propagator;
+mod regin_propagator;
 mod wrapper;
 
 pub use wrapper::{Engine, Solution};

--- a/src/engine/regin_propagator.rs
+++ b/src/engine/regin_propagator.rs
@@ -1,0 +1,183 @@
+//! A custom Pumpkin [`Propagator`] enforcing all-different over a row or column
+//! by wrapping the crate's generalized [`regin`] arc-consistency filter.
+//!
+//! Pumpkin's built-in `all_different` is a pairwise `!=` decomposition, which
+//! misses Hall sets. This propagator instead snapshots the line's domains, runs
+//! [`regin`] for full GAC, and posts every value it removes. Doing so makes the
+//! generalized Régin from #97 the runtime all-different engine, replacing the
+//! built-in decomposition used in step 2.
+//!
+//! ## Explanations
+//!
+//! Each removal is justified by the snapshot domain state: the conjunction of
+//! every `var != w` that already holds across the line (a value `w` removed
+//! from some cell before this call). Régin computed the pruning from exactly
+//! that state, so it entails the removal under all-different. The reason is
+//! coarser than a minimal Hall-set certificate but always sound; tightening it
+//! is a possible later optimization.
+
+use std::rc::Rc;
+
+use pumpkin_solver::core::{
+    convert_case, declare_inference_label, predicate,
+    predicates::{Predicate, PropositionalConjunction},
+    proof::{ConstraintTag, InferenceCode},
+    propagation::{
+        DomainEvents, LocalId, PropagationContext, Propagator, PropagatorConstructor,
+        PropagatorConstructorContext, ReadDomains,
+    },
+    results::PropagationStatusCP,
+    variables::DomainId,
+};
+
+use crate::{Fill, constraints::regin::regin, engine::value_of, types::N};
+
+declare_inference_label!(ReginInference);
+
+/// Constructor (the "args" half) for [`ReginPropagator`]. Registers a watch on
+/// every line variable.
+#[derive(Clone, Debug)]
+pub struct ReginArgs {
+    /// The row or column's cell variables.
+    pub vars: Rc<[DomainId]>,
+    /// Grid size; every variable's initial domain is `1..=n`.
+    pub n: N,
+    /// Tag grouping this line's inferences in the proof log.
+    pub tag: ConstraintTag,
+}
+
+impl PropagatorConstructor for ReginArgs {
+    type PropagatorImpl = ReginPropagator;
+
+    fn create(self, mut context: PropagatorConstructorContext) -> Self::PropagatorImpl {
+        for (i, &var) in self.vars.iter().enumerate() {
+            context.register(
+                var,
+                DomainEvents::ANY_INT,
+                LocalId::from(u32::try_from(i).unwrap_or(u32::MAX)),
+            );
+        }
+        ReginPropagator {
+            code: InferenceCode::new(self.tag, ReginInference),
+            vars: self.vars,
+            n: self.n,
+        }
+    }
+}
+
+/// GAC all-different propagator for one line, backed by [`regin`].
+#[derive(Clone, Debug)]
+pub struct ReginPropagator {
+    vars: Rc<[DomainId]>,
+    n: N,
+    code: InferenceCode,
+}
+
+impl ReginPropagator {
+    /// Reads the current domain of each variable into a [`Fill`] snapshot.
+    fn snapshot(&self, context: &PropagationContext) -> Vec<Fill> {
+        self.vars
+            .iter()
+            .map(|var| context.iterate_domain(var).map(value_of).collect())
+            .collect()
+    }
+
+    /// The sound explanation shared by every removal this call makes: every
+    /// `var != w` already true across the line at snapshot time.
+    fn state_reason(&self, snapshot: &[Fill]) -> PropositionalConjunction {
+        let mut predicates: Vec<Predicate> = Vec::new();
+        for (&var, fill) in self.vars.iter().zip(snapshot) {
+            for w in 1..=self.n {
+                if (*fill & Fill::new([w])).is_empty() {
+                    let absent = i32::from(w);
+                    predicates.push(predicate![var != absent]);
+                }
+            }
+        }
+        predicates.into_iter().collect()
+    }
+}
+
+impl Propagator for ReginPropagator {
+    #[allow(clippy::unnecessary_literal_bound)] // trait fixes the signature to `-> &str`
+    fn name(&self) -> &str {
+        "Regin"
+    }
+
+    fn propagate_from_scratch(&self, mut context: PropagationContext) -> PropagationStatusCP {
+        let snapshot = self.snapshot(&context);
+        let pruned = regin(&snapshot);
+        let reason = self.state_reason(&snapshot);
+        for ((&var, before), after) in self.vars.iter().zip(&snapshot).zip(&pruned) {
+            for value in before.iter() {
+                if (*after & Fill::new([value])).is_empty() {
+                    let removed = i32::from(value);
+                    context.post(predicate![var != removed], reason.clone(), &self.code)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, deprecated)]
+mod tests {
+    use pumpkin_solver::{Solver, core::TestSolver};
+
+    use super::*;
+
+    #[test]
+    fn name_is_regin() {
+        let mut solver = Solver::default();
+        let tag = solver.new_constraint_tag();
+        let vars: Rc<[DomainId]> = Vec::new().into();
+        let propagator = ReginPropagator {
+            vars,
+            n: 4,
+            code: InferenceCode::unknown_label(tag),
+        };
+        assert_eq!(propagator.name(), "Regin");
+    }
+
+    #[test]
+    fn prunes_hall_set_on_4x4_line() {
+        // Two of four cells in a 4-line are pinned to {1,2}. That Hall set
+        // saturates values 1 and 2, so the generalized Régin propagator must
+        // remove both from the other two cells — a prune pairwise `!=` misses.
+        let mut test = TestSolver::default();
+        let a = test.new_variable(1, 4);
+        let b = test.new_variable(1, 4);
+        let c = test.new_variable(1, 4);
+        let d = test.new_variable(1, 4);
+        for var in [a, b] {
+            test.remove(var, 3).unwrap();
+            test.remove(var, 4).unwrap();
+        }
+        let tag = test.new_constraint_tag();
+        let vars: Rc<[DomainId]> = [a, b, c, d].into();
+        let _ = test.new_propagator(ReginArgs { vars, n: 4, tag }).unwrap();
+        for var in [c, d] {
+            assert!(!test.contains(var, 1));
+            assert!(!test.contains(var, 2));
+            assert!(test.contains(var, 3));
+            assert!(test.contains(var, 4));
+        }
+    }
+
+    #[test]
+    fn detects_pigeonhole_conflict() {
+        // Three cells confined to two values has no all-different assignment;
+        // the propagator must report a conflict.
+        let mut test = TestSolver::default();
+        let a = test.new_variable(1, 3);
+        let b = test.new_variable(1, 3);
+        let c = test.new_variable(1, 3);
+        for var in [a, b, c] {
+            test.remove(var, 3).unwrap();
+        }
+        let tag = test.new_constraint_tag();
+        let vars: Rc<[DomainId]> = [a, b, c].into();
+        assert!(test.new_propagator(ReginArgs { vars, n: 3, tag }).is_err());
+    }
+}

--- a/src/engine/wrapper.rs
+++ b/src/engine/wrapper.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, rc::Rc};
 
 use pumpkin_solver::{
-    Solver, all_different,
+    Solver,
     conflict_resolvers::resolvers::ResolutionResolver,
     core::{
         results::{ProblemSolution, SatisfactionResult, solution_iterator::IteratedSolution},
@@ -12,7 +12,7 @@ use pumpkin_solver::{
 
 use crate::{
     Cell, Puzzle,
-    engine::{cage_propagator::CageArgs, value_of},
+    engine::{cage_propagator::CageArgs, regin_propagator::ReginArgs, value_of},
     types::N,
 };
 
@@ -23,10 +23,10 @@ pub type Solution = BTreeMap<Cell, N>;
 /// A Pumpkin-backed CSP view of a [`Puzzle`].
 ///
 /// Construction registers one integer decision variable per cell over `1..=n`,
-/// posts a built-in `all_different` for every row and column, and adds a
+/// posts a generalized-Régin all-different
+/// ([`ReginPropagator`](super::regin_propagator::ReginPropagator)) for every row
+/// and column, and adds a
 /// [`CagePropagator`](super::cage_propagator::CagePropagator) for each cage.
-/// The row/column `all_different` is Pumpkin's pairwise decomposition for now;
-/// #98 step 3 replaces it with the generalized Régin propagator.
 pub struct Engine {
     solver: Solver,
     /// Cells in row-major order; `vars[i]` is the variable for `cells[i]`.
@@ -50,16 +50,22 @@ impl Engine {
             .map(|_| solver.new_bounded_integer(1, upper))
             .collect();
         let var_at = |cell: Cell| vars[cell.row * n + cell.column];
+        let grid_size =
+            N::try_from(n).unwrap_or_else(|_| unreachable!("grid size n lies in 1..=9"));
 
-        // Posting cannot fail at the root for a valid puzzle: distinct-variable
-        // all-different is always root-consistent, and a stored cage always has
-        // at least one tuple (an empty one would have failed puzzle
-        // construction), so its propagator empties no domain from full domains.
+        // Posting cannot fail at the root for a valid puzzle: all-different over
+        // distinct variables is root-consistent, and a stored cage always has at
+        // least one tuple (an empty one would have failed puzzle construction),
+        // so its propagator empties no domain from full domains.
         for index in 0..n {
             for line in [row_cells(n, index), column_cells(n, index)] {
-                let line_vars: Vec<DomainId> = line.into_iter().map(var_at).collect();
+                let line_vars: Rc<[DomainId]> = line.into_iter().map(var_at).collect();
                 let tag = solver.new_constraint_tag();
-                let _ = solver.add_constraint(all_different(line_vars, tag)).post();
+                let _ = solver.add_propagator(ReginArgs {
+                    vars: line_vars,
+                    n: grid_size,
+                    tag,
+                });
             }
         }
 


### PR DESCRIPTION
Step 3 of the #98 Pumpkin migration. Targets `spike/pumpkin`; builds on steps 1–2 (merged). Uses the generalized Régin from #97.

## What

- New custom `Propagator`: `engine::regin_propagator::ReginPropagator`, one per row and column. It snapshots the line's domains into `Fill`s, runs the crate's generalized `regin` GAC filter (#97), and posts every value `regin` removes.
- `Engine::new` now uses `ReginPropagator` for all rows/columns **in place of** Pumpkin's built-in pairwise `all_different`, so the engine has true GAC all-different.

## Explanations

Each removal carries a sound (if coarse) eager reason: the conjunction of every `var != w` already true across the line at snapshot time. Régin computed the pruning from exactly that domain state, so it entails the removal under all-different. Tightening to a minimal Hall-set certificate is noted as a possible later optimization.

## Validation

Direct `TestSolver` unit tests on the propagator:
- **Hall-set pruning on the 4×4 line** (the spike case the issue calls out): two cells pinned to `{1,2}` force `1` and `2` out of the other two — a prune pairwise `!=` misses.
- **Pigeonhole conflict**: three cells confined to two values is reported unsatisfiable.

The step-2 agreement tests (solve/enumerate vs. the bespoke solver, cage handling) still pass with Régin swapped in — GAC all-different has the same solution set as pairwise, so enumerate counts are unchanged.

## Gates

fmt, strict clippy (pedantic + nursery + CI deny set), `cargo doc -D warnings`, full suite all pass; `regin_propagator.rs` at 100% line coverage, total 99.76%.

## Next

Step 4: observer `Propagator` feeding the Designer's fixpoint-domain path; step 5: delete the bespoke solver.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbwkRpjgeqefPccePkNK7B)_