### PR TITLE
Pumpkin migration step 4: observer propagator + propagate_to_fixpoint (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     and uses it for every row and column in place of the built-in pairwise
     `all_different`, giving the engine full GAC all-different. Confirmed
     Hall-set pruning on the 4×4 line and pigeonhole conflict detection.
+  - Step 4 adds a read-only observer `Propagator` and
+    `Engine::propagate_to_fixpoint() -> DomainMap`, exposing each cell's
+    candidate domain at the root fixpoint without a full solve (the Designer's
+    per-cell display). Matches the bespoke solver's domains on empty, given,
+    and partially-filled puzzles.
 
 ## [0.3.0] - 2026-05-17
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -15,9 +15,11 @@
 #![allow(dead_code, unused_imports)]
 
 mod cage_propagator;
+mod observer_propagator;
 mod regin_propagator;
 mod wrapper;
 
+pub use observer_propagator::DomainMap;
 pub use wrapper::{Engine, Solution};
 
 use crate::types::N;

--- a/src/engine/observer_propagator.rs
+++ b/src/engine/observer_propagator.rs
@@ -1,0 +1,105 @@
+//! A custom Pumpkin [`Propagator`] that observes, rather than narrows, domains.
+//!
+//! The Designer needs each cell's candidate set at a propagation fixpoint
+//! without running a full solve. This propagator never prunes; it watches every
+//! cell variable and, each time it fires, snapshots their current domains (read
+//! through [`ReadDomains`]) into shared state. Because adding a propagator drives
+//! the solver to a fixpoint, the snapshot taken when the observer is registered
+//! reflects the root fixpoint — exactly the per-cell domains the Designer shows.
+//!
+//! The observer also fires during search (at whatever node Pumpkin re-triggers
+//! it), so callers that want the root fixpoint should read the snapshot taken at
+//! construction time rather than after a solve. [`Engine`](super::Engine) does
+//! this by copying the snapshot out once, immediately after construction.
+
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+
+use pumpkin_solver::core::{
+    propagation::{
+        DomainEvents, LocalId, PropagationContext, Propagator, PropagatorConstructor,
+        PropagatorConstructorContext, ReadDomains,
+    },
+    results::PropagationStatusCP,
+    variables::DomainId,
+};
+
+use crate::{Cell, Fill, engine::value_of};
+
+/// Per-cell candidate domains at a propagation fixpoint, in row-major order.
+pub type DomainMap = BTreeMap<Cell, Fill>;
+
+/// Shared cell the observer writes each domain snapshot into.
+pub type DomainSink = Rc<RefCell<DomainMap>>;
+
+/// Constructor (the "args" half) for [`ObserverPropagator`]. Watches every cell
+/// variable so the observer re-fires whenever a domain changes.
+#[derive(Clone, Debug)]
+pub struct ObserverArgs {
+    /// Cells parallel to `vars`.
+    pub cells: Rc<[Cell]>,
+    /// The cell variables to observe.
+    pub vars: Rc<[DomainId]>,
+    /// Where each snapshot is written.
+    pub sink: DomainSink,
+}
+
+impl PropagatorConstructor for ObserverArgs {
+    type PropagatorImpl = ObserverPropagator;
+
+    fn create(self, mut context: PropagatorConstructorContext) -> Self::PropagatorImpl {
+        for (i, &var) in self.vars.iter().enumerate() {
+            context.register(
+                var,
+                DomainEvents::ANY_INT,
+                LocalId::from(u32::try_from(i).unwrap_or(u32::MAX)),
+            );
+        }
+        ObserverPropagator {
+            cells: self.cells,
+            vars: self.vars,
+            sink: self.sink,
+        }
+    }
+}
+
+/// A read-only propagator: it records the current per-cell domains and prunes
+/// nothing.
+#[derive(Clone, Debug)]
+pub struct ObserverPropagator {
+    cells: Rc<[Cell]>,
+    vars: Rc<[DomainId]>,
+    sink: DomainSink,
+}
+
+impl Propagator for ObserverPropagator {
+    #[allow(clippy::unnecessary_literal_bound)] // trait fixes the signature to `-> &str`
+    fn name(&self) -> &str {
+        "Observer"
+    }
+
+    fn propagate_from_scratch(&self, context: PropagationContext) -> PropagationStatusCP {
+        let snapshot: DomainMap = self
+            .cells
+            .iter()
+            .zip(self.vars.iter())
+            .map(|(&cell, var)| (cell, context.iterate_domain(var).map(value_of).collect()))
+            .collect();
+        *self.sink.borrow_mut() = snapshot;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_observer() {
+        let propagator = ObserverPropagator {
+            cells: Vec::new().into(),
+            vars: Vec::new().into(),
+            sink: DomainSink::default(),
+        };
+        assert_eq!(propagator.name(), "Observer");
+    }
+}

--- a/src/engine/wrapper.rs
+++ b/src/engine/wrapper.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, rc::Rc};
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
 use pumpkin_solver::{
     Solver,
@@ -12,7 +12,12 @@ use pumpkin_solver::{
 
 use crate::{
     Cell, Puzzle,
-    engine::{cage_propagator::CageArgs, regin_propagator::ReginArgs, value_of},
+    engine::{
+        cage_propagator::CageArgs,
+        observer_propagator::{DomainMap, DomainSink, ObserverArgs},
+        regin_propagator::ReginArgs,
+        value_of,
+    },
     types::N,
 };
 
@@ -33,6 +38,9 @@ pub struct Engine {
     cells: Vec<Cell>,
     /// Decision variable per cell, indexed in row-major order.
     vars: Vec<DomainId>,
+    /// Per-cell domains at the root fixpoint, captured by the observer when the
+    /// engine is built (before any search node could overwrite them).
+    root_domains: DomainMap,
 }
 
 impl Engine {
@@ -80,11 +88,30 @@ impl Engine {
             });
         }
 
+        // The observer is added last so its add-time fire — driven by
+        // `add_propagator`'s propagate-to-fixpoint — sees the fully narrowed root
+        // domains. Copy them out immediately; later `solve`/`enumerate` calls
+        // re-fire the observer at search nodes and overwrite the shared sink.
+        let sink: DomainSink = Rc::new(RefCell::new(DomainMap::new()));
+        let _ = solver.add_propagator(ObserverArgs {
+            cells: cells.iter().copied().collect(),
+            vars: vars.iter().copied().collect(),
+            sink: Rc::clone(&sink),
+        });
+        let root_domains = sink.borrow().clone();
+
         Self {
             solver,
             cells,
             vars,
+            root_domains,
         }
+    }
+
+    /// Returns each cell's candidate domain at the root propagation fixpoint —
+    /// the per-cell display the Designer needs without running a full solve.
+    pub fn propagate_to_fixpoint(&self) -> DomainMap {
+        self.root_domains.clone()
     }
 
     /// Finds one solution to the puzzle, or `None` if it is unsatisfiable.
@@ -268,5 +295,72 @@ mod tests {
     fn enumerate_zero_limit_is_empty() {
         let puzzle = Puzzle::new(4).unwrap();
         assert!(Engine::new(&puzzle).enumerate(0).is_empty());
+    }
+
+    /// The bespoke solver's fixpoint domains as a `Cell -> Fill` map.
+    fn reference_domains(puzzle: &Puzzle) -> DomainMap {
+        puzzle.candidates().collect()
+    }
+
+    #[test]
+    fn fixpoint_domains_match_bespoke_solver_on_empty_grid() {
+        let puzzle = Puzzle::new(4).unwrap();
+        assert_eq!(
+            Engine::new(&puzzle).propagate_to_fixpoint(),
+            reference_domains(&puzzle)
+        );
+    }
+
+    #[test]
+    fn fixpoint_domains_match_bespoke_solver_with_given_cage() {
+        // Given(3) at (0,0) pins that cell and narrows its row and column.
+        let puzzle = Puzzle::with_cages(4, &[cage(4, &[(0, 0)], Operation::Given(3))])
+            .unwrap()
+            .unwrap();
+        let domains = Engine::new(&puzzle).propagate_to_fixpoint();
+        assert_eq!(domains, reference_domains(&puzzle));
+        assert_eq!(domains[&Cell::new(0, 0)], crate::Fill::new([3]));
+    }
+
+    #[test]
+    fn fixpoint_domains_match_bespoke_solver_on_partially_filled_puzzles() {
+        // A battery of partially-filled puzzles: the engine's fixpoint per-cell
+        // domains must match the bespoke solver's exactly.
+        let puzzles = [
+            Puzzle::with_cages(
+                4,
+                &[
+                    cage(4, &[(0, 0), (0, 1)], Operation::Subtract(1)),
+                    cage(4, &[(1, 0)], Operation::Given(2)),
+                ],
+            )
+            .unwrap()
+            .unwrap(),
+            Puzzle::with_cages(
+                4,
+                &[
+                    cage(4, &[(0, 0), (1, 0)], Operation::Divide(2)),
+                    cage(4, &[(0, 3)], Operation::Given(4)),
+                ],
+            )
+            .unwrap()
+            .unwrap(),
+            Puzzle::with_cages(
+                3,
+                &[
+                    cage(3, &[(0, 0), (0, 1), (0, 2)], Operation::Add(6)),
+                    cage(3, &[(1, 0)], Operation::Given(1)),
+                ],
+            )
+            .unwrap()
+            .unwrap(),
+        ];
+        for puzzle in &puzzles {
+            assert_eq!(
+                Engine::new(puzzle).propagate_to_fixpoint(),
+                reference_domains(puzzle),
+                "fixpoint mismatch for puzzle {puzzle:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Step 4 of the #98 Pumpkin migration. Targets `spike/pumpkin`; builds on steps 1–3 (merged).

## What

- New read-only custom `Propagator`: `engine::observer_propagator::ObserverPropagator`. It prunes nothing; it watches every cell variable and, each time it fires, snapshots their domains (read via `ReadDomains::iterate_domain`) into a shared `Rc<RefCell<DomainMap>>`.
- `Engine::propagate_to_fixpoint() -> DomainMap` returns each cell's candidate domain at the **root fixpoint** — the per-cell display the Designer needs without running a full solve.

## How the fixpoint capture works

`Solver::add_propagator` drives the solver to a global fixpoint after each addition (verified in the 0.3.0 source). Adding the observer **last** means its add-time fire sees the fully narrowed root domains. The engine copies that snapshot out of the sink immediately after construction, so later `solve`/`enumerate` calls — which re-fire the observer at search nodes — cannot corrupt the root view. (This addresses the issue's risk note that "the observer fires when Pumpkin chooses to fire it.")

## Validation (the step-4 gate)

`propagate_to_fixpoint()` is checked against the bespoke solver's `Puzzle::candidates()` (the Designer's current source of truth):
- empty 4×4 grid;
- a Given cage (pins a cell, narrows its row/column);
- a battery of partially-filled puzzles (Subtract, Divide, Add cages on 3×3 and 4×4).

All match exactly — both engines run the same GAC (cage tuples + Régin all-different), so they share a fixpoint.

## Gates

fmt, strict clippy (pedantic + nursery + CI deny set), `cargo doc -D warnings`, full suite all pass; observer propagator at 100% line coverage, total 99.77%.

## Next

Step 5: delete the bespoke solver (`solver/solve.rs`, the naive `AllDifferent`, the propagation queue) and route `Puzzle` through the engine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbwkRpjgeqefPccePkNK7B)_